### PR TITLE
Rose 'Reference' (User) Guide translation to reStructuredText

### DIFF
--- a/sphinx/ext/rose-lang.py
+++ b/sphinx/ext/rose-lang.py
@@ -28,9 +28,9 @@ class RoseLexer(RegexLexer):
 
     # Pattern for a rose setting with capture groups.
     ROSE_SETTING_PATTERN = (
-        r'([\w\{\}\[\]\-]+'  # setting-name{}[]
-        r'(?:\(.*\))?)'      # Brackets for namelists.
-        r'(\s+)?(=)(\s+)?')  # Optional spaces around = operator, value.
+        r'([\w\{\}\[\]\:\-]+'  # setting-name{}[]
+        r'(?:\(.*\))?)'        # Brackets for namelists.
+        r'(\s+)?(=)(\s+)?')    # Optional spaces around = operator, value.
 
     # Pattern for a rose (ignored|trigger-ignored|regular) setting.
     ROSE_SETTING_VALUE_PATTERN = ('{0}'  # '', '!', '!!'.

--- a/sphinx/hyperlinks.rst
+++ b/sphinx/hyperlinks.rst
@@ -12,3 +12,6 @@
 .. _cylc user guide: http://cylc.github.io/cylc/documentation.html#the-cylc-user-guide
 .. _Jinja2: http://jinja.pocoo.org/
 .. _FCM: https://metomi.github.io/fcm/doc/
+.. _Python: https://www.python.org/
+.. _bash: https://www.gnu.org/software/bash/
+.. _PyGTK: http://www.pygtk.org/

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -18,6 +18,12 @@
 
    command-reference
 
+.. toctree::
+   :caption: User Guide
+   :name: user-guide-toc
+   :maxdepth: 1
+
+   user-guide/variables
 
 Indices and tables
 ==================

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -23,6 +23,9 @@
    :name: user-guide-toc
    :maxdepth: 1
 
+   user-guide/configuration
+   user-guide/configuration-metadata
+   user-guide/API
    user-guide/variables
 
 Indices and tables

--- a/sphinx/tutorial/rose/furthertopics/macro-development.rst
+++ b/sphinx/tutorial/rose/furthertopics/macro-development.rst
@@ -1,3 +1,5 @@
+.. _macro-dev:
+
 Custom Macros
 =============
 

--- a/sphinx/tutorial/rose/furthertopics/widget-development.rst
+++ b/sphinx/tutorial/rose/furthertopics/widget-development.rst
@@ -1,3 +1,5 @@
+.. _widget-dev:
+
 Widget Development
 ==================
 

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -25,7 +25,8 @@ programming interfaces within Rose which are designed for extension. These
 are useful for extending Rose components or creating standalone programs that
 seek to manipulate Rose information.
 
-Most of these interfaces require a good knowledge of Python.
+.. tip::
+   Most of these interfaces require a good knowledge of Python.
 
 
 Rose GTK library
@@ -106,7 +107,8 @@ with the following arguments:
 
      {'type': 'integer', 'help': 'This is used to count something'}
 
-  You may not need to use this information.
+  .. note::
+     You may not need to use this information.
 
 ``set_value``
   a function that should be called with a new string value of this widget,
@@ -198,9 +200,10 @@ to preserve cursor position when a widget is refreshed:
   ``4`` for a variable value of ``Operational`` means that the cursor should
   be placed between the ``r`` and the ``a``.
 
-  This has no real meaning or importance for widgets that don't display
-  editable text. If you do not supply this method, the config editor will
-  attempt to do the right thing anyway.
+  .. note::
+     This has no real meaning or importance for widgets that don't display
+     editable text. If you do not supply this method, the config editor will
+     attempt to do the right thing anyway.
 
 ``get_focus_index() -> focus_index``
   A method that takes no arguments and returns a number which is the
@@ -212,9 +215,11 @@ to preserve cursor position when a widget is refreshed:
          """Return the cursor position."""
          return self.entry.get_position()
 
-  This has no real meaning or importance for widgets that don't display
-  editable text. If you do not supply this method, the config editor will guess
-  the cursor position anyway, based on the last change to the variable value.
+  .. note::
+     This has no real meaning or importance for widgets that don't display
+     editable text. If you do not supply this method, the config editor will
+     guess the cursor position anyway, based on the last change to the
+     variable value.
 
 ``handle_type_error(is_in_error) -> None``
   The default behaviour when a variable error is added or removed is to
@@ -235,12 +240,14 @@ to preserve cursor position when a widget is refreshed:
   normally hidden, but the ``handle_type_error`` shows them if there is an
   error. The method also keeps the keyboard focus, which is the main purpose.
 
-  You may not have much need for this method, as the default error flagging
-  and cursor focus handling is normally sufficient.
+  .. tip::
+     You may not have much need for this method, as the default error
+     flagging and cursor focus handling is normally sufficient.
 
-All the existing variable value widgets are implemented using this API, so
-a good resource is the modules within the
-``lib/python/rose/config_editor/valuewidget package``.
+.. tip::
+   All the existing variable value widgets are implemented using this
+   API, so a good resource is the modules within the
+   ``lib/python/rose/config_editor/valuewidget package``.
 
 .. _conf-ed-cust-pages:
 
@@ -409,8 +416,9 @@ method ``set_ignored`` which takes no arguments. This should examine the
 instance - the variable is ignored if this is not empty. If the variable is
 ignored, the widget should indicate this e.g. by greying out part of it.
 
-All existing page widgets use this API, so a good resource is the modules in
-``lib/python/rose/config_editor/pagewidget/``.
+.. tip::
+   All existing page widgets use this API, so a good resource is the
+   modules in ``lib/python/rose/config_editor/pagewidget/``.
 
 Generally speaking, a visible change, click, or key press in the custom page
 widget should make instant changes to variable value(s), and the value that
@@ -423,10 +431,11 @@ The custom class should return a gtk object to be packed into the page
 framework, so it's best to subclass from an existing gtk Container type
 such as ``gtk.VBox`` (or ``gtk.Table``, in the example above).
 
-In line with the general philosophy, metadata should not be critical to
-page operations - it should be capable of displaying variables even when
-they have no or very little metadata, and still make sense if some
-variables are missing or new.
+.. note::
+   In line with the general philosophy, metadata should not be critical to
+   page operations - it should be capable of displaying variables even when
+   they have no or very little metadata, and still make sense if some
+   variables are missing or new.
 
 Config Editor Custom Sub Panels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -537,8 +546,9 @@ The constructor arguments are:
   would give a ``arg_str`` of ``"arg1 arg2 arg3 ..."``. You can use this to
   help configure your widget.
 
-All existing sub panel widgets use this API, so a good resource is the
-modules in ``lib/python/rose/config_editor/panelwidget/``.
+.. tip::
+   All existing sub panel widgets use this API, so a good resource is the
+   modules in ``lib/python/rose/config_editor/panelwidget/``.
 
 
 Rose Macros
@@ -558,9 +568,10 @@ metadata. There are four types of macros:
 There are built-in rose macros that handle standard behaviour such as trigger
 changing and type checking.
 
-This section explains how to add your own custom macros to transform and
-validate configurations. See :ref:`Upgrade Macro API <rose-upgr-macros>` for
-upgrade macros.
+.. note::
+   This section explains how to add your own custom macros to transform
+   and validate configurations. See
+   :ref:`Upgrade Macro API <rose-upgr-macros>` for upgrade macros.
 
 Macros use a Python API, and should be written in Python, unless you are
 doing something very fancy. In the absence of a Python house style, it's
@@ -568,8 +579,9 @@ usual to follow the standard Python style guidance (`PEP8`_, `PEP257`_).
 
 They can be run within ``rose config-edit`` or via ``rose macro``.
 
-You should avoid writing checker macros if the checking can be expressed via
-metadata.
+.. tip::
+   You should avoid writing checker macros if the checking can be expressed
+   via metadata.
 
 Location
 ^^^^^^^^
@@ -739,8 +751,10 @@ transformer macro could be written as follows to allow the user to input
           """Some transformer macro"""
           return
 
-Note that the extra arguments require default values (``=None`` in this
-example) and that you should add error handling for the input accordingly.
+.. note::
+   The extra arguments require default values (``=None`` in this
+   example) and that you should add error handling for the input
+   accordingly.
 
 On running your macro the user will be prompted to supply values for these
 arguments or accept the default values.
@@ -778,8 +792,9 @@ An example upgrade macro might look like this:
           self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
           return config, self.reports
 
-The class name is unimportant - the ``BEFORE_TAG`` and ``AFTER_TAG`` identify
-the macro.
+.. note::
+   The class name is unimportant - the ``BEFORE_TAG`` and ``AFTER_TAG``
+   identify the macro.
 
 Metadata versions are usually structured in a ``rose-meta/CATEGORY/VERSION/``
 hierarchy - where ``CATEGORY`` denotes the type or family of application
@@ -789,14 +804,15 @@ e.g. ``27.2`` or ``HEAD``.
 Upgrade macros live under the ``CATEGORY`` directory in a ``versions.py``
 file - ``rose-meta/CATEGORY/versions.py``.
 
-If you have many upgrade macros, you may want to separate them into different
-modules in the same directory. You can then import from those in
-``versions.py``, so that they are still exposed in that module. You'll need
-to make your directory a package by creating an ``__init__.py`` file, which
-should contain the line ``import versions``. To avoid conflict with other
-``CATEGORY`` upgrade modules (or other Python modules), please name these
-very modules carefully or use absolute or package level imports like this:
-``from .versionXX_YY import FooBar``.
+.. tip::
+   If you have many upgrade macros, you may want to separate them into
+   different modules in the same directory. You can then import from those
+   in ``versions.py``, so that they are still exposed in that module. You'll
+   need to make your directory a package by creating an ``__init__.py`` file,
+   which should contain the line ``import versions``. To avoid conflict with
+   other ``CATEGORY`` upgrade modules (or other Python modules), please name
+   these very modules carefully or use absolute or package level imports like
+   this: ``from .versionXX_YY import FooBar``.
 
 Upgrade macros are subclasses of ``rose.upgrade.MacroUpgrade``. They have all
 the functionality of the transform macros documented above.

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -1,3 +1,16 @@
+.. include:: ../hyperlinks.rst
+   :start-line: 1
+
+.. _calendar: https://developer.gnome.org/pygtk/stable/class-gtkcalendar.html
+.. _slider: http://www.pygtk.org/pygtk2tutorial/sec-RangeWidgetEample.html
+.. _xdot-based: https://github.com/jrfonseca/xdot.py
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _PEP257: https://www.python.org/dev/peps/pep-0257/
+.. _RESTful: https://en.wikipedia.org/wiki/Representational_state_transfer
+.. _RDBMS: https://en.wikipedia.org/wiki/Relational_database_management_system
+.. _JSON: http://www.json.org/
+
+
 API
 ===
 
@@ -5,7 +18,7 @@ API
 Introduction
 ------------
 
-Rose is mainly implemented in Python and bash.
+Rose is mainly implemented in `Python`_ and `bash`_.
 
 The sub-sections below explain how to make use of various application
 programming interfaces within Rose which are designed for extension. These
@@ -19,7 +32,7 @@ Rose GTK library
 ----------------
 
 The Rose/Rosie GUIs (such as the config editor) are written using the Python
-bindings for the GTK GUI toolkit (PyGTK). You can write your own custom GTK
+bindings for the GTK GUI toolkit (`PyGTK`_). You can write your own custom GTK
 widgets and use them within Rose. They should live with the metadata under 
 the ``lib/python/widget/`` directory.
 
@@ -37,9 +50,9 @@ the default widgets. These have the same API, but live in the metadata
 directories rather than the Rose source code.
 
 For example, you may wish to add widgets that deal with dates (e.g. using
-something based on a calendar widget) or use a slider widget for numbers.
-You may even want something that uses an image-based interface such as a
-latitude-longitude chooser based on a map.
+something based on a `calendar`_ widget) or use a `slider`_ widget for
+numbers. You may even want something that uses an image-based interface
+such as a latitude-longitude chooser based on a map.
 
 Normally, widgets will be placed within the metadata directory for the suite
 or application. Widgets going into the Rose core should be added to the
@@ -49,7 +62,7 @@ distribution.
 Example
 """""""
 
-See the Advanced Tutorial.
+See the :ref:`Advanced Tutorial <widget-dev>`.
 
 API Reference
 """""""""""""
@@ -229,6 +242,8 @@ All the existing variable value widgets are implemented using this API, so
 a good resource is the modules within the
 ``lib/python/rose/config_editor/valuewidget package``.
 
+.. _conf-ed-cust-pages:
+
 Config Editor Custom Pages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -243,8 +258,8 @@ two-dimensional form rather than as a simple list. You may want to strip
 down or add to the information presented by default - e.g. hiding names or
 embedding widgets within a block of help text.
 
-You may even wish to do something off-the-wall such as an xdot-based widget
-set!
+You may even wish to do something off-the-wall such as an `xdot-based`_
+widget set!
 
 API Reference
 """""""""""""
@@ -536,18 +551,20 @@ metadata. There are four types of macros:
 * Changers (transformers) - change a configuration e.g. adding/removing
   options.
 * Upgraders - these are special transformer macros for upgrading and
-  downgrading configurations. (covered in the Upgrade Macro API)
+  downgrading configurations. (covered in the
+  :ref:`Upgrade Macro API <rose-upgr-macros>`)
 * Reporters - output information about a configuration.
 
 There are built-in rose macros that handle standard behaviour such as trigger
 changing and type checking.
 
 This section explains how to add your own custom macros to transform and
-validate configurations. See Upgrade Macro API for upgrade macros.
+validate configurations. See :ref:`Upgrade Macro API <rose-upgr-macros>` for
+upgrade macros.
 
 Macros use a Python API, and should be written in Python, unless you are
 doing something very fancy. In the absence of a Python house style, it's
-usual to follow the standard Python style guidance (PEP8, PEP257).
+usual to follow the standard Python style guidance (`PEP8`_, `PEP257`_).
 
 They can be run within ``rose config-edit`` or via ``rose macro``.
 
@@ -573,7 +590,7 @@ Code
 Examples
 """"""""
 
-See the macro Advanced Tutorial.
+See the macro :ref:`Advanced Tutorial <macro-dev>`.
 
 API Documentation
 """""""""""""""""
@@ -581,11 +598,15 @@ API Documentation
 The ``rose.macro.MacroBase`` class (subclassed by all rose macros) is
 documented here.
 
+.. TODO - add reference link to Rose Config API page (once added) on 'here'.
+
 API Reference
 """""""""""""
 
 Validator, transformer and reporter macros are python classes which subclass
 from ``rose.macro.MacroBase`` (api docs).
+
+.. TODO - add ref link to Rose Config API page (once added) on 'api docs'.
 
 These macros implement their behaviours by providing a ``validate``,
 ``transform`` or ``report`` method. A macro can contain any combination of
@@ -595,6 +616,8 @@ transformer.
 These methods should accept two ``rose.config.ConfigNode`` (api docs)
 instances as arguments - one is the configuration, and one is the metadata
 configuration that provides information about the configuration items.
+
+.. TODO - add ref link to Rose Config API page (once added) on 'api docs'.
 
 A validator macro should look like:
 
@@ -723,6 +746,8 @@ On running your macro the user will be prompted to supply values for these
 arguments or accept the default values.
 
 
+.. _rose-upgr-macros:
+
 Rose Upgrade Macros
 -------------------
 
@@ -779,7 +804,7 @@ the functionality of the transform macros documented above.
 defined for you to call. All methods return ``None`` unless otherwise
 specified.
 
-   .. TODO - something must be done
+.. TODO - complete the python API part that goes here
 
 
 Rosie Web
@@ -787,8 +812,8 @@ Rosie Web
 
 This section explains how to use the Rosie web service API. All Rosie
 discovery services (e.g. ``rosie search``, ``rosie go``, web page) use a
-RESTful API to interrogate a web server, which then interrogates an RDBMS.
-Returned data is encoded in the JSON format.
+`RESTful`_ API to interrogate a web server, which then interrogates an
+`RDBMS`_. Returned data is encoded in the `JSON`_ format.
 
 You may wish to utilise the Python class ``rosie.ws_client.Client`` as an
 alternative to this API.
@@ -809,16 +834,16 @@ supported format is 'json') and use a url that looks like:
 Usage
 ^^^^^
 
-   .. TODO - something must be done
+.. TODO - complete/remove section
 
 
 Rose Python Modules
 -------------------
 
-   .. TODO - something must be done
+.. TODO - complete/remove section
 
 
 Rose Bash Library
 -----------------
 
-   .. TODO - something must be done
+.. TODO - complete/remove section

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -25,7 +25,7 @@ programming interfaces within Rose which are designed for extension. These
 are useful for extending Rose components or creating standalone programs that
 seek to manipulate Rose information.
 
-.. tip::
+.. note::
    Most of these interfaces require a good knowledge of Python.
 
 
@@ -247,7 +247,7 @@ to preserve cursor position when a widget is refreshed:
 .. tip::
    All the existing variable value widgets are implemented using this
    API, so a good resource is the modules within the
-   ``lib/python/rose/config_editor/valuewidget package``.
+   ``lib/python/rose/config_editor/valuewidget`` package.
 
 .. _conf-ed-cust-pages:
 

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -78,149 +78,147 @@ This class should have a constructor of the form
 with the following arguments
 
 value
-    a string that represents the value that the widget should display.
+  a string that represents the value that the widget should display.
+
 metadata
+  a map or dictionary of configuration metadata properties for this value,
+  such as
 
-    a map or dictionary of configuration metadata properties for this value,
-such as
+  .. code-block:: python
 
-   .. code-block:: python
+     {'type': 'integer', 'help': 'This is used to count something'}
 
-      {'type': 'integer', 'help': 'This is used to count something'}
+  You may not need to use this information.
 
-    You may not need to use this information.
 set_value
+  a function that should be called with a new string value of this widget,
+  e.g.
 
-    a function that should be called with a new string value of this widget,
-e.g.
+  .. code-block:: python
 
-   .. code-block:: python
-
-      set_value("20")
+     set_value("20")
 
 hook
+  An instance of a class rose.config_editor.valuewidget.ValueWidgetHook
+  containing callback functions that you should connect some of your widgets
+  to.
 
-    An instance of a class rose.config_editor.valuewidget.ValueWidgetHook
-containing callback functions that you should connect some of your widgets to.
 arg_str
+  a keyword argument that stores extra text given to the widget option in
+  the metadata, if any:
 
-    a keyword argument that stores extra text given to the widget option in
-the metadata, if any:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
 
-      widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
+  would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
+  your widget - for example, for a table based widget, you might give the 
+  column names:
 
-    would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
-your widget - for example, for a table based widget, you might give the 
-column names
-    :
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit]=table.TableValueWidget NAME ID WEIGHTING
 
-      widget[rose-config-edit]=table.TableValueWidget NAME ID WEIGHTING
-
-    This means that you can write a generic widget and then configure it for
-different cases. 
+  This means that you can write a generic widget and then configure it for
+  different cases. 
 
 hook contains some callback functions that you should implement:
 
 hook.get_focus(widget) -> None
+  which you should connect your top-level widget (self) to as follows:
 
-    which you should connect your top-level widget (self) to as follows:
+  .. code-block:: python
 
-   .. code-block:: python
+     self.grab_focus = lambda: hook.get_focus(my_favourite_focus_widget)
 
-      self.grab_focus = lambda: hook.get_focus(my_favourite_focus_widget)
+  or define a method in your class
 
-    or define a method in your class
+  .. code-block:: python
 
-   .. code-block:: python
+     def grab_focus(self):
+         """Override the focus method, so we can scroll to a particular widget."""
+         return hook.get_focus(my_favourite_focus_widget)
 
-      def grab_focus(self):
-          """Override the focus method, so we can scroll to a particular widget."""
-          return hook.get_focus(my_favourite_focus_widget)
+  which allows the correct widget (my_favourite_focus_widget) in your
+  container to receive the focus such as a gtk.Entry
+  (my_favourite_focus_widget) and will also trigger a scroll action on a config
+  editor page. This is important to implement to get the proper global find 
+  functionality.
 
-    which allows the correct widget (my_favourite_focus_widget) in your
-container to receive the focus such as a gtk.Entry
-(my_favourite_focus_widget) and will also trigger a scroll action on a config
-editor page. This is important to implement to get the proper global find 
-functionality.
 hook.trigger_scroll(widget) -> None
+  accessed by
 
-    accessed by
+  .. code-block:: python
 
-   .. code-block:: python
+     hook.trigger_scroll(my_favourite_focus_widget)
 
-      hook.trigger_scroll(my_favourite_focus_widget)
+  This should be connected to the focus-in-event GTK signal of your
+  top-level widget (self):
 
-    This should be connected to the focus-in-event GTK signal of your
-top-level widget (self):
+  .. code-block:: python
 
-   .. code-block:: python
-
-      self.entry.connect('focus-in-event',
+     self.entry.connect('focus-in-event',
                          hook.trigger_scroll)
 
-    This also is used to trigger a config editor page scroll to your widget.
+  This also is used to trigger a config editor page scroll to your widget.
 
 You may implement the following optional methods for your widget, which help
 to preserve cursor position when a widget is refreshed:
 
 set_focus_index(focus_index) -> None
+  A method that takes a number as an argument, which is the current cursor
+  position relative to the characters in the variable value:
 
-    A method that takes a number as an argument, which is the current cursor
-position relative to the characters in the variable value:
+  .. code-block:: python
 
-   .. code-block:: python
+     def set_focus_index(self, focus_index):
+         """Set the cursor position to focus_index."""
+         self.entry.set_position(focus_index)
 
-      def set_focus_index(self, focus_index):
-          """Set the cursor position to focus_index."""
-          self.entry.set_position(focus_index)
+  For example, a focus_index of 0 means that your widget should set the
+  cursor position to the beginning of the value. A focus_index of 4 for a
+  variable value of Operational means that the cursor should be placed between
+  the r and the a.
 
-    For example, a focus_index of 0 means that your widget should set the
-cursor position to the beginning of the value. A focus_index of 4 for a
-variable value of Operational means that the cursor should be placed between
-the r and the a.
+  This has no real meaning or importance for widgets that don't display
+  editable text. If you do not supply this method, the config editor will
+  attempt to do the right thing anyway.
 
-    This has no real meaning or importance for widgets that don't display
-editable text. If you do not supply this method, the config editor will
-attempt to do the right thing anyway.
 get_focus_index() -> focus_index
+  A method that takes no arguments and returns a number which is the
+  current cursor position relative to the characters in the variable value:
 
-    A method that takes no arguments and returns a number which is the
-current cursor position relative to the characters in the variable value:
+  .. code-block:: python
 
-   .. code-block:: python
+     def get_focus_index(self):
+         """Return the cursor position."""
+         return self.entry.get_position()
 
-      def get_focus_index(self):
-          """Return the cursor position."""
-          return self.entry.get_position()
+  This has no real meaning or importance for widgets that don't display
+  editable text. If you do not supply this method, the config editor will guess
+  the cursor position anyway, based on the last change to the variable value.
 
-    This has no real meaning or importance for widgets that don't display
-editable text. If you do not supply this method, the config editor will guess
-the cursor position anyway, based on the last change to the variable value.
 handle_type_error(is_in_error) -> None
+  The default behaviour when a variable error is added or removed is to
+  re-instantiate the widget (refresh and redraw it). This can be overridden
+  by defining this method in your value widget class. It takes a boolean
+  is_in_error which is True if there is a value (type) error and False
+  otherwise:
 
-    The default behaviour when a variable error is added or removed is to
-re-instantiate the widget (refresh and redraw it). This can be overridden
-by defining this method in your value widget class. It takes a boolean
-is_in_error which is True if there is a value (type) error and False otherwise:
+  .. code-block:: python
 
-   .. code-block:: python
+     def handle_type_error(self, is_in_error):
+         """Change behaviour based on whether the variable is_in_error."""
+         icon_id = gtk.STOCK_DIALOG_ERROR if is_in_error else None
+         self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
 
-      def handle_type_error(self, is_in_error):
-          """Change behaviour based on whether the variable is_in_error."""
-          icon_id = gtk.STOCK_DIALOG_ERROR if is_in_error else None
-          self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
+  For example, this is used in a built-in widget for the quoted string
+  types string and character. The quotes around the text are normally hidden,
+  but the handle_type_error shows them if there is an error. The method also
+  keeps the keyboard focus, which is the main purpose.
 
-    For example, this is used in a built-in widget for the quoted string
-types string and character. The quotes around the text are normally hidden,
-but the handle_type_error shows them if there is an error. The method also
-keeps the keyboard focus, which is the main purpose.
-
-    You may not have much need for this method, as the default error flagging
-and cursor focus handling is normally sufficient.
+  You may not have much need for this method, as the default error flagging
+  and cursor focus handling is normally sufficient.
 
 All the existing variable value widgets are implemented using this API, so
 a good resource is the modules within the
@@ -269,107 +267,114 @@ The class can inherit from any gtk.Container-derived class.
 The constructor arguments are
 
 real_variable_list
-    a list of the Variable objects (x.name, x.value, x.metadata, etc from
-the rose.variable module). These are the objects you will need to generate
-your widgets around.
+  a list of the Variable objects (x.name, x.value, x.metadata, etc from
+  the rose.variable module). These are the objects you will need to generate
+  your widgets around.
+
 missing_variable_list
-    a list of 'missing' Variable objects that could be added to the container.
-You will only need to worry about these if you plan to show them by
-implementing the 'View Latent' menu functionality that we'll discuss
-further on.
+  a list of 'missing' Variable objects that could be added to the container.
+  You will only need to worry about these if you plan to show them by
+  implementing the 'View Latent' menu functionality that we'll discuss
+  further on.
+
 variable_functions_inst
-    an instance of the class
-rose.config_editor.ops.variable.VariableOperations.
-This contains methods to operate on the variables.
-These will update the undo stack and take care of any errors.
-These methods are the only ways that you should write to the variable states
-or values. For documentation, see the module
-lib/python/rose/config_editor/ops/variable.py.
+  an instance of the class rose.config_editor.ops.variable.VariableOperations.
+  This contains methods to operate on the variables. These will update the
+  undo stack and take care of any errors. These methods are the only ways that
+  you should write to the variable states or values. For documentation, see 
+  the module lib/python/rose/config_editor/ops/variable.py.
+
 show_modes_dict
-    a dictionary that looks like this:
+  a dictionary that looks like this:
 
-   .. code-block:: python
+  .. code-block:: python
 
-      show_modes_dict = {'latent': False, 'fixed': False, 'ignored': True,
-                         'user-ignored': False, 'title': False,
-                         'flag:optional': False, 'flag:no-meta': False}
+     show_modes_dict = {'latent': False, 'fixed': False, 'ignored': True,
+                        'user-ignored': False, 'title': False,
+                        'flag:optional': False, 'flag:no-meta': False}
 
-    which could be ignored for most custom pages, as you need. The meaning of
-the different keys in a non-custom page is:
+  which could be ignored for most custom pages, as you need. The meaning of
+  the different keys in a non-custom page is:
 
-    'latent'
-        False means don't display widgets for variables in the metadata or
-that have been deleted (the variable_list.ghosts variables)
-    'fixed'
-        False means don't display widgets for variables if they only have
-one value set in the metadata values option.
-    'ignored'
-        False means don't display widgets for variables if they're
-ignored (in the configuration, but commented out).
-    'user-ignored'
-        (If ignored is False) False means don't display widgets for
-user-ignored variables. True means always show user-ignored variables.
-    'title'
-        Short for 'View with no title', False means show the title of a
-variable, True means show the variable name instead.
-    'flag:optional'
-        True means indicate if a variable is optional, and False means do
-not show an indicator.
-    'flag:no-meta'
-        True means indicate if a variable has any metadata content, and
-False means do not show an indicator.
+  'latent'
+    False means don't display widgets for variables in the metadata or
+    that have been deleted (the variable_list.ghosts variables)
 
-    If you wish to implement actions based on changes in these properties
-(e.g. displaying and hiding fixed variables depending on the 'fixed'
-setting), the custom page widget should expose a method named
-'show_mode_change' followed by the key. However, 'ignored' is handled
-separately (more below). These methods should take a single boolean that
-indicates the display status. For example:
+  'fixed'
+    False means don't display widgets for variables if they only have
+    one value set in the metadata values option.
 
-   .. code-block:: python
+  'ignored'
+    False means don't display widgets for variables if they're
+    ignored (in the configuration, but commented out).
 
-      def show_fixed(self, should_show)
+  'user-ignored'
+    (If ignored is False) False means don't display widgets for
+    user-ignored variables. True means always show user-ignored variables.
 
-    The argument should_show is a boolean. If True, fixed variables should
-be shown. If False, they should be hidden by your custom container.
+  'title'
+    Short for 'View with no title', False means show the title of a
+    variable, True means show the variable name instead.
+
+  'flag:optional'
+    True means indicate if a variable is optional, and False means do
+    not show an indicator.
+
+  'flag:no-meta'
+    True means indicate if a variable has any metadata content, and
+    False means do not show an indicator.
+
+  If you wish to implement actions based on changes in these properties
+  (e.g. displaying and hiding fixed variables depending on the 'fixed'
+  setting), the custom page widget should expose a method named
+  'show_mode_change' followed by the key. However, 'ignored' is handled
+  separately (more below). These methods should take a single boolean that
+  indicates the display status. For example:
+
+  .. code-block:: python
+
+     def show_fixed(self, should_show)
+
+  The argument should_show is a boolean. If True, fixed variables should
+  be shown. If False, they should be hidden by your custom container.
+
 arg_str
+  a keyword argument that stores extra text given to the widget option
+  in the metadata, if any:
 
-    a keyword argument that stores extra text given to the widget option
-in the metadata, if any:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
 
-      widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
+  would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
+  your widget - for example, for a table based widget, you might give the
+  column names:
 
-    would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
-your widget - for example, for a table based widget, you might give the
-column names
-    :
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
 
-      widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
-
-    This means that you can write a generic widget and then configure it
-for different cases. 
+  This means that you can write a generic widget and then configure it
+  for different cases. 
 
 Refreshing the whole page in order to display a small change to a variable
 (the default) can be undesirable. To deal with this, custom page widgets can
 optionally expose some variable-change specific methods that do this
-themselves. These take a single rose.variable.Variable instance as an argument.
+themselves. These take a single rose.variable.Variable instance as an
+argument.
 
 def add_variable_widget(self, variable) -> None
-    will be called when a variable is created.
+  will be called when a variable is created.
 def reload_variable_widget(self, variable) -> None
-    will be called when a variable's status is changed, e.g. it goes into
-an error state.
+  will be called when a variable's status is changed, e.g. it goes into
+  an error state.
 def remove_variable_widget(self, variable) -> None
-    will be called when a variable is removed.
+  will be called when a variable is removed.
 def update_ignored(self) -> None
-    will be called to allow you to update ignored widget display, if (for
-example) you show/hide ignored variables. If you don't have any custom
-behaviour for ignored variables, it's worth writing a method that does
-nothing - e.g. one that contains just pass).
+  will be called to allow you to update ignored widget display, if (for
+  example) you show/hide ignored variables. If you don't have any custom
+  behaviour for ignored variables, it's worth writing a method that does
+  nothing - e.g. one that contains just pass).
 
 If you take the step of using your own variable widgets, rather than the
 VariableWidget class in lib/python/rose/config_editor/variable.py (the default
@@ -446,59 +451,65 @@ The class can inherit from any gtk.Container-derived class.
 The constructor arguments are:
 
 section_dict
-    a dictionary (map, hash) of section name keys and section data object
-values (instances of the rose.section.Section class). These contain some of
-the data such as section ignored status and comments that you may want to
-present. These objects can usually be used by the section_functions_inst
-methods as arguments - for example, passed in in order to ignore or enable
-a section.
+  a dictionary (map, hash) of section name keys and section data object
+  values (instances of the rose.section.Section class). These contain some of
+  the data such as section ignored status and comments that you may want to
+  present. These objects can usually be used by the section_functions_inst
+  methods as arguments - for example, passed in in order to ignore or enable
+  a section.
+
 variable_dict
-    a dictionary (map, hash) of section name keys and lists of variable data
-objects (instances of the rose.variable.Variable class). These contain useful
-information for the variable (option) such as state, value, and comments.
-Like section data objects, these can usually be used as arguments to the
-variable_functions_inst methods to accomplish things like changing a variable
-value or adding or removing a variable.
+  a dictionary (map, hash) of section name keys and lists of variable data
+  objects (instances of the rose.variable.Variable class). These contain useful
+  information for the variable (option) such as state, value, and comments.
+  Like section data objects, these can usually be used as arguments to the
+  variable_functions_inst methods to accomplish things like changing a variable
+  value or adding or removing a variable.
+
 section_functions_inst
-    an instance of the class rose.config_editor.ops.section.SectionOperations.
-This contains methods to operate on the variables. These will update the undo
-stack and take care of any errors. Together with sub_functions_inst, these
-methods are the only ways that you should write to the section states or
-other attributes. For documentation, see the module
-lib/python/rose/config_editor/ops/section.py.
+  an instance of the class rose.config_editor.ops.section.SectionOperations.
+  This contains methods to operate on the variables. These will update the
+  undo stack and take care of any errors. Together with sub_functions_inst,
+  these methods are the only ways that you should write to the section states
+  or other attributes. For documentation, see the module
+  lib/python/rose/config_editor/ops/section.py.
+
 variable_functions_inst
-    an instance of the class
-rose.config_editor.ops.variable.VariableOperations.
-This contains methods to operate on the variables. These will update the
-undo stack and take care of any errors. These methods are the only ways
-that you should write to the variable states or values. For documentation,
-see the module lib/python/rose/config_editor/ops/variable.py.
+  an instance of the class
+  rose.config_editor.ops.variable.VariableOperations.
+  This contains methods to operate on the variables. These will update the
+  undo stack and take care of any errors. These methods are the only ways
+  that you should write to the variable states or values. For documentation,
+  see the module lib/python/rose/config_editor/ops/variable.py.
+
 search_for_id_function
-    a function that accepts a setting id (a section name, or a variable id)
-as an argument and asks the config editor to navigate to the page for that
-setting. You could use this to allow a click on a section name in your widget
-to launch the page for the section.
+  a function that accepts a setting id (a section name, or a variable id)
+  as an argument and asks the config editor to navigate to the page for that
+  setting. You could use this to allow a click on a section name in your widget
+  to launch the page for the section.
+
 sub_functions_inst
-    an instance of the class rose.config_editor.ops.group.SubDataOperations.
-This contains some convenience methods specifically for sub panels, such as
-operating on many sections at once in an optimised way. For documentation,
-see the module lib/python/rose/config_editor/ops/group.py.
+  an instance of the class rose.config_editor.ops.group.SubDataOperations.
+  This contains some convenience methods specifically for sub panels, such as
+  operating on many sections at once in an optimised way. For documentation,
+  see the module lib/python/rose/config_editor/ops/group.py.
+
 is_duplicate_boolean
-    a boolean that denotes whether or not the sub-namespaces in the summary
-data consist only of duplicate sections (e.g. only namelist:foo(1),
-namelist:foo(2), ...). For example, this could be used by your widget to
-decide whether to implement a "Copy section" user option.
+  a boolean that denotes whether or not the sub-namespaces in the summary
+  data consist only of duplicate sections (e.g. only namelist:foo(1),
+  namelist:foo(2), ...). For example, this could be used by your widget to
+  decide whether to implement a "Copy section" user option.
+
 arg_str
+  a keyword argument that stores extra text given to the widget option
+  in the metadata, if any - e.g.:
 
-    a keyword argument that stores extra text given to the widget option
-in the metadata, if any - e.g.:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
 
-      widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
-
-    would give a arg_str of "arg1 arg2 arg3 ...". You can use this to help 
-configure your widget.
+  would give a arg_str of "arg1 arg2 arg3 ...". You can use this to help 
+  configure your widget.
 
 All existing sub panel widgets use this API, so a good resource is the
 modules in lib/python/rose/config_editor/panelwidget/.

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -58,8 +58,10 @@ The procedure for implementing a custom value widget is as follows:
 Assign a widget[rose-config-edit] attribute to the relevant variable in the
 metadata configuration, e.g.
 
-[namelist:VerifConNL/ScalarAreaCodes]
-widget[rose-config-edit]=module_name.AreaCodeChooser
+   .. code-block:: rose
+
+      [namelist:VerifConNL/ScalarAreaCodes]
+      widget[rose-config-edit]=module_name.AreaCodeChooser
 
 where the widget class lives in the module module_name under
 lib/python/widget/ in the metadata directory for the application or suite.
@@ -67,9 +69,11 @@ Modules are imported by the config editor on demand.
 
 This class should have a constructor of the form
 
-class AreaCodeChooser(gtk.HBox):
+   .. code-block:: python
 
-    def __init__(self, value, metadata, set_value, hook, arg_str=None)
+      class AreaCodeChooser(gtk.HBox):
+
+          def __init__(self, value, metadata, set_value, hook, arg_str=None)
 
 with the following arguments
 
@@ -80,7 +84,9 @@ metadata
     a map or dictionary of configuration metadata properties for this value,
 such as
 
-    {'type': 'integer', 'help': 'This is used to count something'}
+   .. code-block:: python
+
+      {'type': 'integer', 'help': 'This is used to count something'}
 
     You may not need to use this information.
 set_value
@@ -88,7 +94,9 @@ set_value
     a function that should be called with a new string value of this widget,
 e.g.
 
-    set_value("20")
+   .. code-block:: python
+
+      set_value("20")
 
 hook
 
@@ -99,14 +107,18 @@ arg_str
     a keyword argument that stores extra text given to the widget option in
 the metadata, if any:
 
-    widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
+   .. code-block:: rose
+
+      widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
 
     would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
 your widget - for example, for a table based widget, you might give the 
 column names
     :
 
-    widget[rose-config-edit]=table.TableValueWidget NAME ID WEIGHTING
+   .. code-block:: rose
+
+      widget[rose-config-edit]=table.TableValueWidget NAME ID WEIGHTING
 
     This means that you can write a generic widget and then configure it for
 different cases. 
@@ -117,14 +129,17 @@ hook.get_focus(widget) -> None
 
     which you should connect your top-level widget (self) to as follows:
 
-        self.grab_focus = lambda: hook.get_focus(my_favourite_focus_widget)
+   .. code-block:: python
+
+      self.grab_focus = lambda: hook.get_focus(my_favourite_focus_widget)
 
     or define a method in your class
 
-    def grab_focus(self):
-        """Override the focus method, so we can scroll to a particular
-widget."""
-        return hook.get_focus(my_favourite_focus_widget)
+   .. code-block:: python
+
+      def grab_focus(self):
+          """Override the focus method, so we can scroll to a particular widget."""
+          return hook.get_focus(my_favourite_focus_widget)
 
     which allows the correct widget (my_favourite_focus_widget) in your
 container to receive the focus such as a gtk.Entry
@@ -135,13 +150,17 @@ hook.trigger_scroll(widget) -> None
 
     accessed by
 
-        hook.trigger_scroll(my_favourite_focus_widget)
+   .. code-block:: python
+
+      hook.trigger_scroll(my_favourite_focus_widget)
 
     This should be connected to the focus-in-event GTK signal of your
 top-level widget (self):
 
-            self.entry.connect('focus-in-event',
-                               hook.trigger_scroll)
+   .. code-block:: python
+
+      self.entry.connect('focus-in-event',
+                         hook.trigger_scroll)
 
     This also is used to trigger a config editor page scroll to your widget.
 
@@ -153,9 +172,11 @@ set_focus_index(focus_index) -> None
     A method that takes a number as an argument, which is the current cursor
 position relative to the characters in the variable value:
 
-    def set_focus_index(self, focus_index):
-        """Set the cursor position to focus_index."""
-        self.entry.set_position(focus_index)
+   .. code-block:: python
+
+      def set_focus_index(self, focus_index):
+          """Set the cursor position to focus_index."""
+          self.entry.set_position(focus_index)
 
     For example, a focus_index of 0 means that your widget should set the
 cursor position to the beginning of the value. A focus_index of 4 for a
@@ -170,9 +191,11 @@ get_focus_index() -> focus_index
     A method that takes no arguments and returns a number which is the
 current cursor position relative to the characters in the variable value:
 
-    def get_focus_index(self):
-        """Return the cursor position."""
-        return self.entry.get_position()
+   .. code-block:: python
+
+      def get_focus_index(self):
+          """Return the cursor position."""
+          return self.entry.get_position()
 
     This has no real meaning or importance for widgets that don't display
 editable text. If you do not supply this method, the config editor will guess
@@ -184,10 +207,12 @@ re-instantiate the widget (refresh and redraw it). This can be overridden
 by defining this method in your value widget class. It takes a boolean
 is_in_error which is True if there is a value (type) error and False otherwise:
 
-    def handle_type_error(self, is_in_error):
-        """Change behaviour based on whether the variable is_in_error."""
-        icon_id = gtk.STOCK_DIALOG_ERROR if is_in_error else None
-        self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
+   .. code-block:: python
+
+      def handle_type_error(self, is_in_error):
+          """Change behaviour based on whether the variable is_in_error."""
+          icon_id = gtk.STOCK_DIALOG_ERROR if is_in_error else None
+          self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
 
     For example, this is used in a built-in widget for the quoted string
 types string and character. The quotes around the text are normally hidden,
@@ -224,16 +249,20 @@ The procedure for generating a custom page widget is as follows:
 Assign a widget option to the relevant namespace in the metadata
 configuration, e.g.
 
-    [ns:namelist/STASHNUM]
-    widget[rose-config-edit]=module_name.MyGreatBigTable
+   .. code-block:: rose
+
+      [ns:namelist/STASHNUM]
+      widget[rose-config-edit]=module_name.MyGreatBigTable
 
 The widget class should have a constructor of the form
 
-    class MyGreatBigTable(gtk.Table):
+   .. code-block:: python
 
-        def __init__(self, real_variable_list, missing_variable_list,
-                     variable_functions_inst, show_modes_dict,
-                     arg_str=None):
+      class MyGreatBigTable(gtk.Table):
+
+          def __init__(self, real_variable_list, missing_variable_list,
+                       variable_functions_inst, show_modes_dict,
+                       arg_str=None):
 
 The class can inherit from any gtk.Container-derived class.
 
@@ -259,9 +288,11 @@ lib/python/rose/config_editor/ops/variable.py.
 show_modes_dict
     a dictionary that looks like this:
 
-        show_modes_dict = {'latent': False, 'fixed': False, 'ignored': True,
-                           'user-ignored': False, 'title': False,
-                           'flag:optional': False, 'flag:no-meta': False}
+   .. code-block:: python
+
+      show_modes_dict = {'latent': False, 'fixed': False, 'ignored': True,
+                         'user-ignored': False, 'title': False,
+                         'flag:optional': False, 'flag:no-meta': False}
 
     which could be ignored for most custom pages, as you need. The meaning of
 the different keys in a non-custom page is:
@@ -295,7 +326,9 @@ setting), the custom page widget should expose a method named
 separately (more below). These methods should take a single boolean that
 indicates the display status. For example:
 
-    def show_fixed(self, should_show)
+   .. code-block:: python
+
+      def show_fixed(self, should_show)
 
     The argument should_show is a boolean. If True, fixed variables should
 be shown. If False, they should be hidden by your custom container.
@@ -304,14 +337,18 @@ arg_str
     a keyword argument that stores extra text given to the widget option
 in the metadata, if any:
 
-    widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
+   .. code-block:: rose
+
+      widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
 
     would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
 your widget - for example, for a table based widget, you might give the
 column names
     :
 
-    widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
+   .. code-block:: rose
+
+      widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
 
     This means that you can write a generic widget and then configure it
 for different cases. 
@@ -384,8 +421,10 @@ The procedure for generating a custom sub panel widget is as follows:
 Assign a widget[rose-config-edit:sub-ns] option to the relevant namespace
 in the metadata configuration, e.g.
 
-    [ns:namelist/all_the_foo_namelists]
-    widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
+   .. code-block:: rose
+
+      [ns:namelist/all_the_foo_namelists]
+      widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
 
 Note that because the actual data on the page has a separate representation,
 you need to write [rose-config-edit:sub-ns] rather than just
@@ -393,12 +432,14 @@ you need to write [rose-config-edit:sub-ns] rather than just
 
 The widget class should have a constructor of the form
 
-    class MySubPanelForFoos(gtk.VBox):
+   .. code-block:: python
 
-        def __init__(self, section_dict, variable_dict,
-                     section_functions_inst, variable_functions_inst,
-                     search_for_id_function, sub_functions_inst,
-                     is_duplicate_boolean, arg_str=None):
+      class MySubPanelForFoos(gtk.VBox):
+
+          def __init__(self, section_dict, variable_dict,
+                       section_functions_inst, variable_functions_inst,
+                       search_for_id_function, sub_functions_inst,
+                       is_duplicate_boolean, arg_str=None):
 
 The class can inherit from any gtk.Container-derived class.
 
@@ -452,7 +493,9 @@ arg_str
     a keyword argument that stores extra text given to the widget option
 in the metadata, if any - e.g.:
 
-    widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
+   .. code-block:: rose
+
+      widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
 
     would give a arg_str of "arg1 arg2 arg3 ...". You can use this to help 
 configure your widget.
@@ -527,15 +570,17 @@ configuration that provides information about the configuration items.
 
 A validator macro should look like:
 
-import rose.macro
+   .. code-block:: python
 
-class SomeValidator(rose.macro.MacroBase):
+      import rose.macro
 
-    """This does some kind of check."""
+      class SomeValidator(rose.macro.MacroBase):
 
-    def validate(self, config, meta_config=None):
-        # Some check on config appends to self.reports using self.add_report
-        return self.reports
+      """This does some kind of check."""
+
+      def validate(self, config, meta_config=None):
+          # Some check on config appends to self.reports using self.add_report
+          return self.reports
 
 The returned list should be a list of rose.macro.MacroReport objects
 containing the section, option, value, and warning strings for each setting
@@ -543,7 +588,9 @@ that is in error. These are initialised behind the scenes by calling the
 inherited method rose.macro.MacroBase.add_report via self.add_report. This
 has the form:
 
-    def add_report(self, section=None, option=None, value=None, info=None,
+   .. code-block:: python
+
+      def add_report(self, section=None, option=None, value=None, info=None,
                    is_warning=False):
 
 This means that you should call it with the relevant section first, then the
@@ -551,14 +598,16 @@ relevant option, then the relevant value, then the relevant error message,
 and optionally a warning flag that we'll discuss later. If the setting is a
 section, the option should be None and the value None. For example,
 
-    def validate(self, config, meta_config=None):
-        editor_value = config.get(["env", "MY_FAVOURITE_STREAM_EDITOR"]).value
-        if editor_value != "sed":
-            self.add_report("env",                         # Section
-                            "MY_FAVOURITE_STREAM_EDITOR",  # Option
-                            editor_value,                  # Value
-                            "Should be 'sed'!")            # Message
-        return self.reports
+   .. code-block:: python
+
+      def validate(self, config, meta_config=None):
+          editor_value = config.get(["env", "MY_FAVOURITE_STREAM_EDITOR"]).value
+          if editor_value != "sed":
+              self.add_report("env",                         # Section
+                              "MY_FAVOURITE_STREAM_EDITOR",  # Option
+                              editor_value,                  # Value
+                              "Should be 'sed'!")            # Message
+          return self.reports
 
 Validator macros have the option to give warnings, which do not count as
 formal errors in the Rose config editor GUI. These should be used when
@@ -566,23 +615,27 @@ something may be wrong, such as warning when using an advanced-developer-only
 option. They are invoked by passing a 5th argument to self.add_report,
 is_warning, like so:
 
-            self.add_report("env",
-                            "MY_FAVOURITE_STREAM_EDITOR",
-                            editor_value,
-                            "Could be 'sed'",
-                            is_warning=True)
+   .. code-block:: python
+
+      self.add_report("env",
+                      "MY_FAVOURITE_STREAM_EDITOR",
+                      editor_value,
+                      "Could be 'sed'",
+                      is_warning=True)
 
 A transformer macro should look like:
 
-import rose.macro
+   .. code-block:: python
 
-class SomeTransformer(rose.macro.MacroBase):
+      import rose.macro
 
-    """This does some kind of change to the config."""
+      class SomeTransformer(rose.macro.MacroBase):
 
-    def transform(self, config, meta_config=None):
-        # Some operation on config which calls self.add_report for each change.
-        return config, self.reports
+      """This does some kind of change to the config."""
+
+      def transform(self, config, meta_config=None):
+          # Some operation on config which calls self.add_report for each change.
+          return config, self.reports
 
 The returned list should be a list of 4-tuples containing the section,
 option, value, and information strings for each setting that was changed
@@ -591,17 +644,19 @@ option should be None and the value None. If an option was removed, the
 value should be the old value - otherwise it should be the new one
 (added/changed). For example,
 
-    def transform(self, config, meta_config=None):
-        """Add some more snow control."""
-        if config.get(["namelist:snowflakes"]) is None:
-            config.set(["namelist:snowflakes"])
-            self.add_report(list_of_changes,
-                            "namelist:snowflakes", None, None,
-                            "Updated snow handling in time for Christmas")
-            config.set(["namelist:snowflakes", "l_unique"], ".true.")
-            self.add_report("namelist:snowflakes", "l_unique", ".true.",
-                            "So far, anyway.")
-        return config, self.reports
+   .. code-block:: python
+
+      def transform(self, config, meta_config=None):
+          """Add some more snow control."""
+          if config.get(["namelist:snowflakes"]) is None:
+              config.set(["namelist:snowflakes"])
+              self.add_report(list_of_changes,
+                              "namelist:snowflakes", None, None,
+                              "Updated snow handling in time for Christmas")
+              config.set(["namelist:snowflakes", "l_unique"], ".true.")
+              self.add_report("namelist:snowflakes", "l_unique", ".true.",
+                              "So far, anyway.")
+          return config, self.reports
 
 The current working directory within a macro is always the configuration's
 directory. This makes it easy to access non-rose-app.conf files (e.g. in the
@@ -611,23 +666,27 @@ There are also reporter macros which can be used where you need to output
 some information about a configuration. A reporter macro takes the same form
 as validator and transform macros but does not require a return value.
 
-    def report(self, config, meta_config=None):
-        """ Write some information about the configuration to a report file.
+   .. code-block:: python
 
-        Note: report methods do not have a return value.
+       def report(self, config, meta_config=None):
+           """ Write some information about the configuration to a report file.
 
-        """
-        with open('report/file', 'r') as report_file:
-            report_file.write(str(config.get(["namelist:snowflakes"])))
+           Note: report methods do not have a return value.
+
+           """
+           with open('report/file', 'r') as report_file:
+               report_file.write(str(config.get(["namelist:snowflakes"])))
 
 Macros also support the use of keyword arguments, giving you the ability to
 have the user specify some input or override to your macro. For example a
 transformer macro could be written as follows to allow the user to input
 some_value:
 
-    def transform(self, config, meta_config=None, some_value=None):
-        """Some transformer macro"""
-        return
+   .. code-block:: python
+
+      def transform(self, config, meta_config=None, some_value=None):
+          """Some transformer macro"""
+          return
 
 Note that the extra arguments require default values (=None in this example)
 and that you should add error handling for the input accordingly.
@@ -652,17 +711,19 @@ above, but with a few differences:
 
 An example upgrade macro might look like this:
 
-class Upgrade272to273(rose.upgrade.MacroUpgrade):
+   .. code-block:: python
 
-    """Upgrade from 27.2 to 27.3."""
+      class Upgrade272to273(rose.upgrade.MacroUpgrade):
 
-    BEFORE_TAG = "27.2"
-    AFTER_TAG = "27.3"
+      """Upgrade from 27.2 to 27.3."""
 
-    def upgrade(self, config, meta_config=None):
-        self.add_setting(config, ["env", "NEW_VARIABLE"], "0")
-        self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
-        return config, self.reports
+      BEFORE_TAG = "27.2"
+      AFTER_TAG = "27.3"
+
+      def upgrade(self, config, meta_config=None):
+          self.add_setting(config, ["env", "NEW_VARIABLE"], "0")
+          self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
+          return config, self.reports
 
 The class name is unimportant - the BEFORE_TAG and AFTER_TAG identify the
 macro.
@@ -689,198 +750,7 @@ the functionality of the transform macros documented above.
 rose.upgrade.MacroUpgrade also has some additional convenience methods
 defined for you to call. All methods return None unless otherwise specified.
 
-def act_from_files(self, config, downgrade=False)
-
-    A method that takes the app configuration (config, a
-rose.config.ConfigNode instance) and an optional boolean downgrade keyword
-argument. This initiates a search for etc/VERSION/rose-macro-add.conf and
-etc/VERSION/rose-macro-remove.conf, where VERSION is equal to the BEFORE_TAG
-of the macro. These files should be Rose app config-like patch files,
-containing settings to be added (rose-macro-add.conf) and settings to be
-removed (rose-macro-remove.conf). If downgrading (downgrade set to True),
-the settings in rose-macro-remove.conf will be added, and the ones in
-rose-macro-add.conf removed.
-
-        def upgrade(self, config, meta_config=None):
-            self.act_from_files(config)
-            return config, self.reports
-
-    Note that you can use other methods (below) as well as this in the
-same upgrade.
-
-    If settings are defined in either file, and changes can be made,
-the self.reports will be updated automatically.
-def add_setting(self, config, keys, value=None, forced=False, state=None,
-comments=None, info=None):
-
-    A method that attempts to add the setting defined by the list keys
-([section] or [section, option] strings) with the value value to the app
-config config. The arguments mostly follow rose.config.ConfigNode 
-attributes, and are as follows:
-
-    config
-        The application configuration object (rose.config.ConfigNode instance)
-    keys
-        A list of strings denoting config settings - [section_name] for a
-section, [section_name, option_name] for an option. For example, it might
-be ["namelist:foo", "bar"].
-    value (optional)
-        A string or None denoting the new setting value. None should be
-used for sections only. Options must have a string value defined.
-    forced (optional)
-        If the setting already exists, override the value to the new value.
-    state (optional)
-        Set the state of the new setting (rose.config.ConfigNode
-states) - None implies the default, which is
-rose.config.ConfigNode.STATE_NORMAL. You may also use
-rose.config.ConfigNode.STATE_USER_IGNORED.
-    comments (optional)
-        A list of comment strings (lines) for the new setting or None.
-    info (optional)
-        A short string containing no new lines, describing the addition of
-the setting.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.add_setting(config, ["namelist:breakfast_nl", "bacon"], "2",
-                             comments=["Mmmm. Bacon."], info="Add for
-food:#810")
-            return config, self.reports
-
-def change_setting_value(self, config, keys, value, forced=False,
-comments=None, info=None):
-
-    A method that attempts to change an existing setting value defined by
-keys to a new one (value) in the app config config. The arguments are:
-
-    config, keys, comments, info
-        As in add_setting above.
-    value
-        Required argument, must be a string for option values, and can be
-None for section values.
-    forced (optional)
-        Add the setting if it does not exist.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.change_setting_value(config, ["namelist:breakfast_nl",
-"coffee"], "'more'",
-                                      info="Add for food:#820")
-            return config, self.reports
-
-def get_setting_value(self, config, keys, no_ignore=False): (-> value)
-
-    A method that returns a setting value or None, functionally similar to
-rose.config.ConfigNode.get. The arguments are:
-
-    config, keys
-
-        As in add_setting above.
-    no_ignore (optional)
-        False means return the setting value if the setting is ignored. True
-means return None if the setting is ignored. If the setting is missing, None
-is returned.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            if self.get_setting_value(
-                        config, ["namelist:breakfast_nl", "coffee"]) == "'empty'":
-                self.add_setting(config, ["namelist:breakfast_nl", "tea"],
-                                 "'extra_strong'")
-            return config, self.reports
-
-def remove_setting(self, config, keys, info=None):
-
-    A method that removes a setting defined by keys in config with an
-optional info message. The arguments are:
-
-    config, keys, info
-        As in add_setting above.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.remove_setting(config, ["namelist:breakfast_nl", "cheeseburger"],
-                                info="Cheeseburgers are for lunch")
-            return config, self.reports
-
-    Example of removing an entire namelist:
-
-        def upgrade(self, config, meta_config=None):
-            self.remove_setting(config, ["namelist:breakfast_nl"],
-                                info="We don't serve breakfast anymore")
-            return config, self.reports
-
-def rename_setting(self, config, keys, new_keys, info=None):
-
-    A method that attempts to rename the setting defined by the list keys
-([section] or [section, option] strings) to the new name defined by new_keys.
-The arguments mostly follow rose.config.ConfigNode attributes, and are as
-follows:
-
-    config
-        The application configuration object (rose.config.ConfigNode instance)
-    keys
-        A list of strings denoting config settings - [section_name] for a
-section, [section_name, option_name] for an option. For example, it might be
-["namelist:foo", "bar_old"].
-    new_keys
-        A list of strings denoting config settings - [section_name] for a
-section, [section_name, option_name] for an option. For example, it might be
-["namelist:foo", "bar_new"].
-    info (optional)
-        A short string containing no new lines, describing the renaming of
-the setting.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.rename_setting(config, ["namelist:breakfast_nl", "bad_coffee"],
-                                ["namelist:breakfast_nl", "good_coffee"],
-                                info="Mmmm... nicer coffee...")
-            return config, self.reports
-
-def enable_setting(self, config, keys, info=None):
-
-    A method to make sure a setting defined by keys in config is not
-user-ignored. The arguments are:
-
-    config, keys, info
-        As in add_setting above.
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.enable_setting(config, ["namelist:breakfast_nl", "egg_monitoring"])
-            return config, self.reports
-
-def ignore_setting(self, config, keys, info=None, state=rose.config.ConfigNode.STATE_USER_IGNORED):
-
-    Inverse of enable_setting, a method to make sure a setting defined by
-keys in config is ignored (default state is user-ignored). The arguments are:
-
-    config, keys, info
-        As in add_setting above.
-    state
-        One of rose.config.ConfigNode.STATE_USER_IGNORED (default),
-rose.config.ConfigNode.STATE_SYST_IGNORED (trigger-ignored). When using it,
-you can just use config.STATE... rather than the full
-rose.config.ConfigNode.STATE....
-
-    Example usage:
-
-        def upgrade(self, config, meta_config=None):
-            self.ignore_setting(config, ["namelist:breakfast_nl", "milk_bottle_date"])
-            return config, self.reports
-
-There is an upgrade macro development tutorial and more examples in the
-upgrade file for the upgrade usage tutorial (versions.py), at
-$ROSE_HOME/etc/rose-meta/rose-demo-upgrade/versions.py, where $ROSE_HOME
-is the path to your local Rose distribution, locatable by invoking rose
---version.
+   .. TODO - something must be done
 
 
 Rosie Web
@@ -908,425 +778,16 @@ http://host/PREFIX_NAME/get_known_keys?format=json
 Usage
 ^^^^^
 
-The API contains the following methods:
-
-get_known_keys
-    returns the main property names stored for suites (e.g. idx, branch,
-owner) plus any additional names specified in the site config and takes
-the format argument. For example, entering a URL in a web browser:
-
-    http://host/PREFIX_NAME/get_known_keys?format=json
-
-    may give
-
-    ["access-list", "idx", "branch", "owner", "project", "revision",
-"status",  "title"]
-
-get_optional_keys
-    returns all unique optional or user-defined property names given in
-suite discovery information and takes the format argument. For example,
-entering this URL in Firefox:
-
-    http://host/PREFIX_NAME/get_optional_keys?format=json
-
-    may give
-
-    ["access-list", "description", "endgame_status", "operational_flag",
-"tag-list"]
-
-get_query_operators
-    returns all the SQL-like operators used to compare column values that
-you may use in queries (below) (e.g. eq, ne, contains, like) and takes the
-format argument. For example, entering this URL in a web browser:
-
-    http://host/PREFIX_NAME/get_query_operators?format=json
-
-    may give
-
-    ["eq", "ge", "gt", "le", "lt", "ne", "contains", "endswith", "ilike",
-"like", "match", "startswith"]
-
-query
-    takes a list of queries q and the format argument. The syntax of the
-query looks like:
-
-    CONJUNCTION+[OPEN_GROUP+]FIELD+OPERATOR+VALUE[+CLOSE_GROUP]
-
-    where
-
-    CONJUNCTION
-        and or or
-    OPEN_GROUP
-        optional, one or more (
-    FIELD
-        e.g. idx or description
-    OPERATOR
-        e.g. contains or between, one of the operators returned by
-get_query_operators
-    VALUE
-        e.g. euro4m or 200
-    CLOSE_GROUP
-        optional, one or more )
-
-    The first CONJUNCTION is technically superfluous. The OPEN_GROUP and
-CLOSE_GROUP do not have to be used. Entering this URL in a web browser:
-
-    http://host/PREFIX_NAME/query?q=and+idx+endswith+78&q=or+owner+eq+bob&format=json
-
-    may give
-
-    [{"idx": "mo1-aa078", "branch": "trunk", "revision": 200, "owner": "fred",
-      "project": "fred's project.", "title": "fred's awesome suite",
-      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"},
-     {"idx": "mo1-aa090", "branch": "trunk", "revision": 350, "owner": "bob",
-      "project": "var", "title": "A copy of var.vexcs.", "status": "M ",
-      "access-list": ["*"], "operational": "Y"}]
-
-    This returned all current suites that have an idx that ends with 78 and
-also all suites that have the owner bob. Each suite is returned as an entry
-in a list - each entry is an associative array of property name-value pairs.
-These pairs contain all database information about a suite.
-
-    query also takes the optional argument all_revs which switches on
-searching older revisions of current suites and deleted suites. For example,
-entering this URL in a web browser:
-
-    http://host/mo1/json/query?q=and+idx+endswith+78&all_revs&format=json
-
-    may give
-
-    [{"idx": "mo1-aa078", "branch": "trunk", "revision": 120, "owner": "fred",
-      "project": "fred's project.", "title": "fred's new suite",
-      "status": "A "}
-     {"idx": "mo1-aa078", "branch": "trunk", "revision": 199, "owner": "fred",
-      "project": "fred's project.", "title": "fred's awesome suite",
-      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"},
-     {"idx": "mo1-aa078", "branch": "trunk", "revision": 200, "owner": "fred",
-      "project": "fred's project.", "title": "fred's awesome suite",
-      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"}]
-
-    This returned all past and present suites that have an idx that ends
-with 78. You can see that older revisions of the aa078 suite appear.
-
-    You can also use parentheses in your search to group expressions. For
-example, entering this URL in a web browser:
-
-    http://host/PREFIX_NAME/query?q=and+(+owner+eq+bob&q=or+owner+eq+fred+)&q=and+project+eq+test&format=json
-
-    would search for all suites that are owned by bob or fred that have the
-project test.
-search
-    takes any number of string arguments and the format argument and returns
-a list of matching suites with properties in the same format as query. The
-suite database is searched for suites with any property with a value that
-contains any of the string arguments. For example, entering this URL in a
-web browser:
-
-    http://host/PREFIX_NAME/search?var+bob+nowcast&format=json
-
-    may give
-
-    [{"idx": "mo1-aa090", "branch": "trunk", "revision": 330, "owner": "bob",
-      "project": "um", "title": "A copy of um.alpra.", "status": "M ",
-      "description": "Bob's UM suite"},
-     {"idx": "mo1-aa092", "branch": "trunk", "revision": 340, "owner": "jim",
-      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
-      "location": "NAE"},
-     {"idx": "mo1-aa100", "branch": "trunk", "revision": 352, "owner": "ops_account",
-      "project": "nowcast", "title": "The operational Nowcast suite",
-      "status": "M ", "ensemble": "yes"}]
-
-    This returned all suites that contain one or more of these search terms.
-Each suite is returned as an entry in a list, and each entry is an
-associative array of suite property name-value pairs. These pairs contain
-all database information about a suite.
-
-    search also takes the optional argument all_revs in the same way as
-query, above. This switches on searching older revisions of current suites
-and deleted suites. For example, entering this URL in a web browser:
-
-    http://host/PREFIX_NAME/search?var+bob&all_revs&format=json
-
-    may give
-
-    [{"idx": "mo1-aa001", "branch": "trunk", "revision": 120, "owner": "bob",
-      "project": "useless", "title": "Bob's useless suite.", "status": "A "},
-     {"idx": "mo1-aa001", "branch": "trunk", "revision": 122, "owner": "bob",
-      "project": "useless", "title": "Bob's useless suite.", "status": "D "},
-     {"idx": "mo1-aa090", "branch": "trunk", "revision": 320, "owner": "bob",
-      "project": "um", "title": "A copy of um.alpra.", "status": "A "},
-     {"idx": "mo1-aa090", "branch": "trunk", "revision": 321, "owner": "bob",
-      "project": "um", "title": "A copy of um.alpra.", "status": "M "},
-     {"idx": "mo1-aa090", "branch": "trunk", "revision": 330, "owner": "bob",
-      "project": "um", "title": "A copy of um.alpra.", "status": "M "},
-     {"idx": "mo1-aa092", "branch": "trunk", "revision": 335, "owner": "jim",
-      "project": "var", "title": "6D Quantum VAR.", "status": "A "},
-     {"idx": "mo1-aa092", "branch": "trunk", "revision": 338, "owner": "jim",
-      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
-      "location": "Africa"},
-     {"idx": "mo1-aa092", "branch": "trunk", "revision": 340, "owner": "jim",
-      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
-      "location": "NAE"}]
-
-    This returned all past and present suites that contained a match for at
-least one of the search terms. Older versions of suites appear, and you can
-also see a deleted suite (aa001).
+   .. TODO - something must be done
 
 
 Rose Python Modules
 -------------------
 
-This gives some brief information about Rose python modules. For more
-information, see the files themselves.
-
-Rose Main Modules
-^^^^^^^^^^^^^^^^^
-
-This section describes the modules under the lib/python/rose package.
-
-rose
-    (__init__.py) stores some constants used by Rose programs.
-rose.app_run
-    callable, Rose application runner.
-rose.apps.*
-    (package) built-in Rose applications.
-rose.bush
-    callable, Rose Bush services logic.
-rose.c3
-    library, implements the C3 algorithm (e.g. to linearise multiple
-inheritance).
-rose.checksum
-    library, determine the MD5 checksum for a file or files in a directory.
-rose.config
-    library, parses and dumps rose configuration files. Contains the main
-configuration object rose.config.ConfigNode which is manipulated in most
-rose programs.
-rose.config_cli
-    callable, implements the rose config command.
-rose.config_dump
-    callable, implements the rose config-dump command.
-rose.config_editor/*
-    (package) Rose configuration editor logic. See Rose Config Editor Modules.
-rose.config_processor
-    library, base class for rose configuration processing.
-rose.config_processors
-    (package) subclasses for rose configuration processing.
-rose.config_tree
-    library, representation of a Rose configruation directory.
-rose.date
-    callable, implements the rose date command. Contains date shift library.
-rose.env
-    library, handles environment variable substitution.
-rose.env_cat
-    callable, implements rose env-cat command.
-rose.external
-    library, contains minimal wrapper functions for calling external programs.
-rose.formats
-    (package) contains modules that deal with supported format parsing. The
-only current supported format is Fortran namelist, through
-rose.formats.namelist.
-rose.fs_util
-    library, file system utilities with event reporting.
-rose.gtk
-    (package) contains modules that deal with generic GTK operations and
-contain shared widgets.
-rose.host_select
-    callable, ranks and selects host machines.
-rose.job_runner
-    library, run jobs with multiple processes.
-rose.macro
-    callable, runs internal and custom macros for an application or suite.
-rose.macros
-    (package) Built-in macros. See Rose Build-in Macro Modules.
-rose.meta_type
-    library, classes for the various metadata type groups.
-rose.meta_type
-    library, data types in a Rose configuration metadata.
-rose.metadata_check
-    callable, validates configuration metadata.
-rose.metadata_gen
-    callable, generates template metadata for an application.
-rose.metadata_graph
-    callable, implement the rose metadata-graph command.
-rose.namelist_dump
-    callable, dumps namelist files to a Rose configuration object.
-rose.opt_parse
-    library, contains an optparse.OptionParser subclass. All command-line
-option parsing in Rose should use this.
-rose.popen
-    library, utilities for spawning and monitoring processes.
-rose.resource
-    library, locates files or directories.
-rose.run
-    library, base class for application, suite and task runners.
-rose.run_source_vc
-    library, functions to print out version control information for rose
-suite-run.
-rose.scheme_handler
-    library, logic to load python modules based on named schemes.
-rose.section
-    library, contains section-specific data utilities. Counterpart of
-rose.variable.
-rose.stem
-    callable, converts user-friendly options for testing code into options
-for rose suite-run.
-rose.suite_clean
-    callable, remove runtime directories of suites.
-rose.suite_control
-    Invoke control commands (currently gcontrol and shutdown) of a running
-suite.
-rose.suite_engine_proc
-    library, base class and utilities for interacting with a suite engine.
-rose.suite_engine_procs
-    (package) library for interacting with specific suite engines.
-rose.suite_hook
-    callable, hooks to suite engine events.
-rose.suite_log
-    callable, implements the rose suite-log command.
-rose.suite_restart
-    callable, implements the rose suite-restart command.
-rose.suite_run
-    callable, suite runner.
-rose.suite_scan
-    callable, scans for running suites.
-rose.task_env
-    callable, provides an environment for a suite task.
-rose.task_run
-    callable, task runner.
-rose.upgrade
-    library, provides configuration upgrade functionality.
-rose.variable
-    library, utilities for processing metadata and a basic data structure
-used by the config editor to hold values and metadata for options.
-rose.ws
-    library, logic for web services, e.g. Rose Bush and Rosie Disco.
-
-Rose Config Editor Modules
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This section describes the modules under the lib/python/rose/config_editor
-package. These are specific to the config editor.
-
-rose.config_editor
-    (__init__.py) stores some constants used for display in the config editor.
-All of these can be overridden using your user config.
-rose.config_editor.keywidget, rose.config_editor.menuwidget,
-rose.config_editor.pagewidget (package), rose.config_editor.variable,
-rose.config_editor.valuewidget (package)
-    These contain GTK code that control the adding/removing/modifying of
-options on a config editor tab. These can all be overridden using custom
-widgets (especially rose.config_editor.valuewidget modules).
-rose.config_editor.loader
-    This controls the loading and retrieval of configuration data within the
-config editor.
-rose.config_editor.main
-    This contains the centralised main control code of the config
-editor - updates, undo stack, etc.
-rose.config_editor.menu
-    This module contains the menu for the config editor and various
-menu-related functions such as adding and removing sections.
-rose.config_editor.page
-    This module contains control code for each config editor tab, and
-interfaces with rose.config_editor.pagewidget objects (including custom
-pages).
-rose.config_editor.panel
-    This creates and alters the GTK Treeview panel of the config editor.
-rose.config_editor.stack
-    This holds the Undo and Redo stack templates, and contains various
-functions to alter variables. This is the main functional interface for 
-custom pages.
-rose.config_editor.util
-    Various small utilities.
-rose.config_editor.window
-    Creates the main GTK window of the config editor and provides functions
-to launch dialogs.
-
-Rose Built-in Macro Modules
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The lib/python/rose/macros package contains built-in macros that perform
-checking against metadata. Most of these are run each time something changes
-in the config editor. They can be run on the command line via rose macro.
-
-rose.macros.compulsory
-    checks/fixes compulsory sections and options
-rose.macros.format
-    checks format-specific sections and options, using options in
-rose.formats modules
-rose.macros.rule
-    checks fail-if and warn-if metadata conditions
-rose.macros.trigger
-    checks trigger validity and transforms configuration ignored states
-rose.macros.value
-    checks type, range, length, pattern, or values metadata
-
-Rosie Modules
-^^^^^^^^^^^^^
-
-This section describes the modules under the lib/python/rosie package.
-
-rosie.browser
-    (package) GTK client code for rosie (rosie go).
-rosie.browser.history
-    Methods and classes for recording suite search history. Used by rosie go.
-rosie.browser.main
-    Main control code for rosie go.
-rosie.browser.result
-    Custom widget with methods for displaying suite search results. Used by
-rosie go.
-rosie.browser.status
-    Classes for getting and updating statuses for checked out suites. Used by
-rosie go.
-rosie.browser.suite
-    Contains a wrapper class for handling the creation, copying, checking out
-and deleting of suites. Used by rosie go.
-rosie.browser.util
-    Library of widgets for rosie.browser.
-rosie.db
-    Interface code to the suite database, called by the web server.
-rosie.db_create
-    Callable, implements rosa db-create command.
-rosie.graph
-    Callable, implements rosie graph command.
-rosie.suite_id
-    Callable, implements the rosie id command to identify suites.
-rosie.svn_post_commit
-    Callable, implements the rosa svn-post-commit command.
-rosie.svn_pre_commit
-    Callable, implements the rosa svn-pre-commit command.
-rosie.usertools.*
-    (package) logic shared by rosa svn-post-commit and rosa svn-pre-commit for
-accessing user information, e.g. from Unix password file or LDAP.
-rosie.vc
-    Callable, implements wrappers to version control system.
-rosie.ws
-    Callable, Rosie Discovery service (Rosie Disco).
-rosie.ws_client
-    Library, Rosie Disco clients.
-rosie.ws_client_auth
-    Library, Rosie Disco client authentication schemes and keyring
-management.
-rosie.ws_client_cli
-    Callable, Rosie Disco CLI clients.
+   .. TODO - something must be done
 
 
 Rose Bash Library
 -----------------
 
-They live under lib/bash/. Each module contains a set of functions. To import
-a module, load the file into your script. E.g. To load rose_usage, you would
-do:
-
-. $ROSE_HOME/lib/bash/rose_usage
-
-The modules are:
-
-rose_init
-    Called by rose on initialisation. This is not meant to be a module for
-general use.
-rose_log
-    Provide functions to print log messages.
-rose_usage
-    If your script has a header similar to the ones used by a Rose command
-line utility, you can use this function to print the synopsis section of the
-script header.
+   .. TODO - something must be done

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -21,7 +21,7 @@ Rose GTK library
 The Rose/Rosie GUIs (such as the config editor) are written using the Python
 bindings for the GTK GUI toolkit (PyGTK). You can write your own custom GTK
 widgets and use them within Rose. They should live with the metadata under 
-the lib/python/widget/ directory.
+the ``lib/python/widget/`` directory.
 
 Value Widgets
 ^^^^^^^^^^^^^
@@ -43,19 +43,22 @@ latitude-longitude chooser based on a map.
 
 Normally, widgets will be placed within the metadata directory for the suite
 or application. Widgets going into the Rose core should be added to the
-lib/python/rose/config_editor/valuewidget/ directory in a Rose distribution.
+``lib/python/rose/config_editor/valuewidget/`` directory in a Rose
+distribution.
+
 Example
 
 See the Advanced Tutorial.
+
 API Reference
 
 All value widgets, custom or core, use the same API. This means that a good
 ractical reference is the set of existing value widgets in the package
-rose.config_editor.valuewidget.
+``rose.config_editor.valuewidget``.
 
 The procedure for implementing a custom value widget is as follows:
 
-Assign a widget[rose-config-edit] attribute to the relevant variable in the
+Assign a ``widget[rose-config-edit]`` attribute to the relevant variable in the
 metadata configuration, e.g.
 
    .. code-block:: rose
@@ -63,8 +66,8 @@ metadata configuration, e.g.
       [namelist:VerifConNL/ScalarAreaCodes]
       widget[rose-config-edit]=module_name.AreaCodeChooser
 
-where the widget class lives in the module module_name under
-lib/python/widget/ in the metadata directory for the application or suite.
+where the widget class lives in the module ``module_name`` under
+``lib/python/widget/`` in the metadata directory for the application or suite.
 Modules are imported by the config editor on demand.
 
 This class should have a constructor of the form
@@ -77,10 +80,10 @@ This class should have a constructor of the form
 
 with the following arguments
 
-value
+``value``
   a string that represents the value that the widget should display.
 
-metadata
+``metadata``
   a map or dictionary of configuration metadata properties for this value,
   such as
 
@@ -90,7 +93,7 @@ metadata
 
   You may not need to use this information.
 
-set_value
+``set_value``
   a function that should be called with a new string value of this widget,
   e.g.
 
@@ -98,22 +101,22 @@ set_value
 
      set_value("20")
 
-hook
-  An instance of a class rose.config_editor.valuewidget.ValueWidgetHook
+``hook``
+  An instance of a class ``rose.config_editor.valuewidget.ValueWidgetHook``
   containing callback functions that you should connect some of your widgets
   to.
 
-arg_str
-  a keyword argument that stores extra text given to the widget option in
-  the metadata, if any:
+``arg_str``
+  a keyword argument that stores extra text given to the ``widget`` option
+  in the metadata, if any:
 
   .. code-block:: rose
 
      widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
 
-  would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
-  your widget - for example, for a table based widget, you might give the 
-  column names:
+  would give a ``arg_str`` of ``"arg1 arg2 arg3 ..."``. This could help
+  configure your widget - for example, for a table based widget, you might
+  give the column names:
 
   .. code-block:: rose
 
@@ -122,10 +125,10 @@ arg_str
   This means that you can write a generic widget and then configure it for
   different cases. 
 
-hook contains some callback functions that you should implement:
+``hook`` contains some callback functions that you should implement:
 
-hook.get_focus(widget) -> None
-  which you should connect your top-level widget (self) to as follows:
+``hook.get_focus(widget) -> None``
+  which you should connect your top-level widget (``self``) to as follows:
 
   .. code-block:: python
 
@@ -139,21 +142,21 @@ hook.get_focus(widget) -> None
          """Override the focus method, so we can scroll to a particular widget."""
          return hook.get_focus(my_favourite_focus_widget)
 
-  which allows the correct widget (my_favourite_focus_widget) in your
+  which allows the correct widget (``my_favourite_focus_widget``) in your
   container to receive the focus such as a gtk.Entry
-  (my_favourite_focus_widget) and will also trigger a scroll action on a config
-  editor page. This is important to implement to get the proper global find 
-  functionality.
+  (``my_favourite_focus_widget``) and will also trigger a scroll action on
+  a config editor page. This is important to implement to get the proper
+  global find functionality.
 
-hook.trigger_scroll(widget) -> None
+``hook.trigger_scroll(widget) -> None``
   accessed by
 
   .. code-block:: python
 
      hook.trigger_scroll(my_favourite_focus_widget)
 
-  This should be connected to the focus-in-event GTK signal of your
-  top-level widget (self):
+  This should be connected to the ``focus-in-event`` GTK signal of your
+  top-level widget (``self``):
 
   .. code-block:: python
 
@@ -165,7 +168,7 @@ hook.trigger_scroll(widget) -> None
 You may implement the following optional methods for your widget, which help
 to preserve cursor position when a widget is refreshed:
 
-set_focus_index(focus_index) -> None
+``set_focus_index(focus_index) -> None``
   A method that takes a number as an argument, which is the current cursor
   position relative to the characters in the variable value:
 
@@ -175,16 +178,16 @@ set_focus_index(focus_index) -> None
          """Set the cursor position to focus_index."""
          self.entry.set_position(focus_index)
 
-  For example, a focus_index of 0 means that your widget should set the
-  cursor position to the beginning of the value. A focus_index of 4 for a
-  variable value of Operational means that the cursor should be placed between
-  the r and the a.
+  For example, a ``focus_index`` of ``0`` means that your widget should set
+  the cursor position to the beginning of the value. A ``focus_index`` of
+  ``4`` for a variable value of ``Operational`` means that the cursor should
+  be placed between the ``r`` and the ``a``.
 
   This has no real meaning or importance for widgets that don't display
   editable text. If you do not supply this method, the config editor will
   attempt to do the right thing anyway.
 
-get_focus_index() -> focus_index
+``get_focus_index() -> focus_index``
   A method that takes no arguments and returns a number which is the
   current cursor position relative to the characters in the variable value:
 
@@ -198,12 +201,12 @@ get_focus_index() -> focus_index
   editable text. If you do not supply this method, the config editor will guess
   the cursor position anyway, based on the last change to the variable value.
 
-handle_type_error(is_in_error) -> None
+``handle_type_error(is_in_error) -> None``
   The default behaviour when a variable error is added or removed is to
   re-instantiate the widget (refresh and redraw it). This can be overridden
   by defining this method in your value widget class. It takes a boolean
-  is_in_error which is True if there is a value (type) error and False
-  otherwise:
+  ``is_in_error`` which is ``True`` if there is a value (type) error and
+  ``False`` otherwise:
 
   .. code-block:: python
 
@@ -213,16 +216,16 @@ handle_type_error(is_in_error) -> None
          self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
 
   For example, this is used in a built-in widget for the quoted string
-  types string and character. The quotes around the text are normally hidden,
-  but the handle_type_error shows them if there is an error. The method also
-  keeps the keyboard focus, which is the main purpose.
+  types ``string`` and ``character``. The quotes around the text are
+  normally hidden, but the ``handle_type_error`` shows them if there is an
+  error. The method also keeps the keyboard focus, which is the main purpose.
 
   You may not have much need for this method, as the default error flagging
   and cursor focus handling is normally sufficient.
 
 All the existing variable value widgets are implemented using this API, so
 a good resource is the modules within the
-lib/python/rose/config_editor/valuewidget package.
+``lib/python/rose/config_editor/valuewidget package``.
 
 Config Editor Custom Pages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -240,11 +243,12 @@ embedding widgets within a block of help text.
 
 You may even wish to do something off-the-wall such as an xdot-based widget
 set!
+
 API Reference
 
 The procedure for generating a custom page widget is as follows:
 
-Assign a widget option to the relevant namespace in the metadata
+Assign a ``widget`` option to the relevant namespace in the metadata
 configuration, e.g.
 
    .. code-block:: rose
@@ -262,29 +266,30 @@ The widget class should have a constructor of the form
                        variable_functions_inst, show_modes_dict,
                        arg_str=None):
 
-The class can inherit from any gtk.Container-derived class.
+The class can inherit from any ``gtk.Container``\-derived class.
 
 The constructor arguments are
 
-real_variable_list
-  a list of the Variable objects (x.name, x.value, x.metadata, etc from
-  the rose.variable module). These are the objects you will need to generate
-  your widgets around.
+``real_variable_list``
+  a list of the Variable objects (``x.name``, ``x.value``, ``x.metadata``,
+  etc from the ``rose.variable`` module). These are the objects you will
+  need to generate your widgets around.
 
-missing_variable_list
+``missing_variable_list``
   a list of 'missing' Variable objects that could be added to the container.
   You will only need to worry about these if you plan to show them by
-  implementing the 'View Latent' menu functionality that we'll discuss
+  implementing the ``'View Latent'`` menu functionality that we'll discuss
   further on.
 
-variable_functions_inst
-  an instance of the class rose.config_editor.ops.variable.VariableOperations.
-  This contains methods to operate on the variables. These will update the
+``variable_functions_inst``
+  an instance of the class
+  ``rose.config_editor.ops.variable.VariableOperations``. This contains
+  methods to operate on the variables. These will update the
   undo stack and take care of any errors. These methods are the only ways that
   you should write to the variable states or values. For documentation, see 
-  the module lib/python/rose/config_editor/ops/variable.py.
+  the module ``lib/python/rose/config_editor/ops/variable.py``.
 
-show_modes_dict
+``show_modes_dict``
   a dictionary that looks like this:
 
   .. code-block:: python
@@ -296,59 +301,59 @@ show_modes_dict
   which could be ignored for most custom pages, as you need. The meaning of
   the different keys in a non-custom page is:
 
-  'latent'
+  ``'latent'``
     False means don't display widgets for variables in the metadata or
-    that have been deleted (the variable_list.ghosts variables)
+    that have been deleted (the ``variable_list.ghosts`` variables)
 
-  'fixed'
+  ``'fixed'``
     False means don't display widgets for variables if they only have
-    one value set in the metadata values option.
+    one value set in the metadata ``values`` option.
 
-  'ignored'
+  ``'ignored'``
     False means don't display widgets for variables if they're
     ignored (in the configuration, but commented out).
 
-  'user-ignored'
-    (If ignored is False) False means don't display widgets for
+  ``'user-ignored'``
+    (If ``ignored`` is False) False means don't display widgets for
     user-ignored variables. True means always show user-ignored variables.
 
-  'title'
+  ``'title'``
     Short for 'View with no title', False means show the title of a
     variable, True means show the variable name instead.
 
-  'flag:optional'
-    True means indicate if a variable is optional, and False means do
+  ``'flag:optional'``
+    True means indicate if a variable is ``optional``, and False means do
     not show an indicator.
 
-  'flag:no-meta'
+  ``'flag:no-meta'``
     True means indicate if a variable has any metadata content, and
     False means do not show an indicator.
 
   If you wish to implement actions based on changes in these properties
   (e.g. displaying and hiding fixed variables depending on the 'fixed'
   setting), the custom page widget should expose a method named
-  'show_mode_change' followed by the key. However, 'ignored' is handled
-  separately (more below). These methods should take a single boolean that
-  indicates the display status. For example:
+  ``'show_mode_change'`` followed by the key. However, ``'ignored'`` is
+  handled separately (more below). These methods should take a single
+  boolean that indicates the display status. For example:
 
   .. code-block:: python
 
      def show_fixed(self, should_show)
 
-  The argument should_show is a boolean. If True, fixed variables should
+  The argument ``should_show`` is a boolean. If True, fixed variables should
   be shown. If False, they should be hidden by your custom container.
 
-arg_str
-  a keyword argument that stores extra text given to the widget option
+``arg_str``
+  a keyword argument that stores extra text given to the ``widget`` option
   in the metadata, if any:
 
   .. code-block:: rose
 
      widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
 
-  would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
-  your widget - for example, for a table based widget, you might give the
-  column names:
+  would give a ``arg_str`` of ``"arg1 arg2 arg3 ..."``. This could help
+  configure your widget - for example, for a table based widget, you might
+  give the column names:
 
   .. code-block:: rose
 
@@ -363,42 +368,42 @@ optionally expose some variable-change specific methods that do this
 themselves. These take a single rose.variable.Variable instance as an
 argument.
 
-def add_variable_widget(self, variable) -> None
+``def add_variable_widget(self, variable) -> None``
   will be called when a variable is created.
-def reload_variable_widget(self, variable) -> None
+``def reload_variable_widget(self, variable) -> None``
   will be called when a variable's status is changed, e.g. it goes into
   an error state.
-def remove_variable_widget(self, variable) -> None
+``def remove_variable_widget(self, variable) -> None``
   will be called when a variable is removed.
-def update_ignored(self) -> None
+``def update_ignored(self) -> None``
   will be called to allow you to update ignored widget display, if (for
   example) you show/hide ignored variables. If you don't have any custom
   behaviour for ignored variables, it's worth writing a method that does
-  nothing - e.g. one that contains just pass).
+  nothing - e.g. one that contains just ``pass``).
 
 If you take the step of using your own variable widgets, rather than the
-VariableWidget class in lib/python/rose/config_editor/variable.py (the default
-for normal config-edit pages), each variable-specific widget should have an
-attribute variable set to their rose.variable.Variable instance. You can
-implement 'ignored' status display by giving the widget a method set_ignored
-which takes no arguments. This should examine the ignored_reason dictionary
-attribute of the widget's variable instance - the variable is ignored if
-this is not empty. If the variable is ignored, the widget should indicate
-this e.g. by greying out part of it.
+VariableWidget class in ``lib/python/rose/config_editor/variable.py`` (the
+default for normal config-edit pages), each variable-specific widget should
+have an attribute ``variable`` set to their ``rose.variable.Variable``
+instance. You can implement 'ignored' status display by giving the widget a
+method ``set_ignored`` which takes no arguments. This should examine the
+``ignored_reason`` dictionary attribute of the widget's ``variable``
+instance - the variable is ignored if this is not empty. If the variable is
+ignored, the widget should indicate this e.g. by greying out part of it.
 
 All existing page widgets use this API, so a good resource is the modules in
-lib/python/rose/config_editor/pagewidget/.
+``lib/python/rose/config_editor/pagewidget/``.
 
 Generally speaking, a visible change, click, or key press in the custom page
 widget should make instant changes to variable value(s), and the value that
 the user sees. Pages are treated as temporary, superficial views of variable
 data, and changes are always assumed to be made directly to the main copy
 of the configuration in memory (this is automatic when the
-rose.config_editor.ops.variable.VariableOperations methods are used, as
+``rose.config_editor.ops.variable.VariableOperations`` methods are used, as
 they should be). Closing the page shouldn't change, or lose, any data!
 The custom class should return a gtk object to be packed into the page
 framework, so it's best to subclass from an existing gtk Container type
-such as gtk.VBox (or gtk.Table, in the example above).
+such as ``gtk.VBox`` (or ``gtk.Table``, in the example above).
 
 In line with the general philosophy, metadata should not be critical to
 page operations - it should be capable of displaying variables even when
@@ -419,12 +424,13 @@ separate representation.
 
 Sub panels are capable of using quite a lot of functionality such as
 modifying the sections and options in the sub-pages directly.
+
 API Reference
 
 The procedure for generating a custom sub panel widget is as follows:
 
-Assign a widget[rose-config-edit:sub-ns] option to the relevant namespace
-in the metadata configuration, e.g.
+Assign a ``widget[rose-config-edit:sub-ns]`` option to the relevant
+namespace in the metadata configuration, e.g.
 
    .. code-block:: rose
 
@@ -432,8 +438,8 @@ in the metadata configuration, e.g.
       widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
 
 Note that because the actual data on the page has a separate representation,
-you need to write [rose-config-edit:sub-ns] rather than just
-[rose-config-edit].
+you need to write ``[rose-config-edit:sub-ns]`` rather than just
+``[rose-config-edit]``.
 
 The widget class should have a constructor of the form
 
@@ -446,73 +452,74 @@ The widget class should have a constructor of the form
                        search_for_id_function, sub_functions_inst,
                        is_duplicate_boolean, arg_str=None):
 
-The class can inherit from any gtk.Container-derived class.
+The class can inherit from any ``gtk.Container``\-derived class.
 
 The constructor arguments are:
 
-section_dict
+``section_dict``
   a dictionary (map, hash) of section name keys and section data object
-  values (instances of the rose.section.Section class). These contain some of
-  the data such as section ignored status and comments that you may want to
-  present. These objects can usually be used by the section_functions_inst
-  methods as arguments - for example, passed in in order to ignore or enable
-  a section.
+  values (instances of the ``rose.section.Section`` class). These contain
+  some of the data such as section ignored status and comments that you may
+  want to present. These objects can usually be used by the
+  ``section_functions_inst`` methods as arguments - for example, passed in
+  in order to ignore or enable a section.
 
-variable_dict
+``variable_dict``
   a dictionary (map, hash) of section name keys and lists of variable data
-  objects (instances of the rose.variable.Variable class). These contain useful
-  information for the variable (option) such as state, value, and comments.
-  Like section data objects, these can usually be used as arguments to the
-  variable_functions_inst methods to accomplish things like changing a variable
-  value or adding or removing a variable.
+  objects (instances of the ``rose.variable.Variable`` class). These contain
+  useful information for the variable (option) such as state, value, and
+  comments. Like section data objects, these can usually be used as arguments
+  to the ``variable_functions_inst`` methods to accomplish things like
+  changing a variable value or adding or removing a variable.
 
-section_functions_inst
+``section_functions_inst``
   an instance of the class rose.config_editor.ops.section.SectionOperations.
   This contains methods to operate on the variables. These will update the
-  undo stack and take care of any errors. Together with sub_functions_inst,
-  these methods are the only ways that you should write to the section states
-  or other attributes. For documentation, see the module
-  lib/python/rose/config_editor/ops/section.py.
+  undo stack and take care of any errors. Together with
+  ``sub_functions_inst``, these methods are the only ways that you should
+  write to the section states or other attributes. For documentation, see the
+  module ``lib/python/rose/config_editor/ops/section.py``.
 
-variable_functions_inst
+``variable_functions_inst``
   an instance of the class
-  rose.config_editor.ops.variable.VariableOperations.
+  ``rose.config_editor.ops.variable.VariableOperations``.
   This contains methods to operate on the variables. These will update the
   undo stack and take care of any errors. These methods are the only ways
   that you should write to the variable states or values. For documentation,
-  see the module lib/python/rose/config_editor/ops/variable.py.
+  see the module ``lib/python/rose/config_editor/ops/variable.py``.
 
-search_for_id_function
+``search_for_id_function``
   a function that accepts a setting id (a section name, or a variable id)
   as an argument and asks the config editor to navigate to the page for that
   setting. You could use this to allow a click on a section name in your widget
   to launch the page for the section.
 
-sub_functions_inst
-  an instance of the class rose.config_editor.ops.group.SubDataOperations.
-  This contains some convenience methods specifically for sub panels, such as
-  operating on many sections at once in an optimised way. For documentation,
-  see the module lib/python/rose/config_editor/ops/group.py.
+``sub_functions_inst``
+  an instance of the class
+  ``rose.config_editor.ops.group.SubDataOperations``. This contains some
+  convenience methods specifically for sub panels, such as operating on many
+  sections at once in an optimised way. For documentation, see the module
+  ``lib/python/rose/config_editor/ops/group.py``.
 
-is_duplicate_boolean
+``is_duplicate_boolean``
   a boolean that denotes whether or not the sub-namespaces in the summary
-  data consist only of duplicate sections (e.g. only namelist:foo(1),
-  namelist:foo(2), ...). For example, this could be used by your widget to
+  data consist only of duplicate sections (e.g. only ``namelist:foo(1)``,
+  ``namelist:foo(2)``, ...). For example, this could be used by your widget to
   decide whether to implement a "Copy section" user option.
 
-arg_str
-  a keyword argument that stores extra text given to the widget option
+``arg_str``
+  a keyword argument that stores extra text given to the ``widget`` option
   in the metadata, if any - e.g.:
 
   .. code-block:: rose
 
      widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
 
-  would give a arg_str of "arg1 arg2 arg3 ...". You can use this to help 
-  configure your widget.
+  would give a ``arg_str`` of ``"arg1 arg2 arg3 ..."``. You can use this to
+  help configure your widget.
 
 All existing sub panel widgets use this API, so a good resource is the
-modules in lib/python/rose/config_editor/panelwidget/.
+modules in ``lib/python/rose/config_editor/panelwidget/``.
 
 
 Rose Macros
@@ -538,7 +545,7 @@ Macros use a Python API, and should be written in Python, unless you are
 doing something very fancy. In the absence of a Python house style, it's
 usual to follow the standard Python style guidance (PEP8, PEP257).
 
-They can be run within rose config-edit or via rose macro.
+They can be run within ``rose config-edit`` or via ``rose macro``.
 
 You should avoid writing checker macros if the checking can be expressed via
 metadata.
@@ -547,14 +554,14 @@ Location
 ^^^^^^^^
 
 A module containing macros should be stored under a directory
-lib/python/macros/ in the metadata for a configuration. This directory should
-be a Python package.
+``lib/python/macros/`` in the metadata for a configuration. This directory
+should be a Python package.
 
 When developing macros for Rose internals, macros should be placed in the
-rose.macros package in the Rose Python library. They should be referenced by
-the lib/python/rose/macros/__init__.py classes and a call to them can be
-added in the lib/python/rose/config_editor/main.py module if they need to be
-run implicitly by the config editor.
+``rose.macros`` package in the Rose Python library. They should be referenced
+by the ``lib/python/rose/macros/__init__.py`` classes and a call to them can
+be added in the ``lib/python/rose/config_editor/main.py module`` if they need
+to be run implicitly by the config editor.
 
 Code
 ^^^^
@@ -562,21 +569,24 @@ Code
 Examples
 
 See the macro Advanced Tutorial.
+
 API Documentation
 
-The rose.macro.MacroBase class (subclassed by all rose macros) is documented
-here.
+The ``rose.macro.MacroBase`` class (subclassed by all rose macros) is
+documented here.
+
 API Reference
 
 Validator, transformer and reporter macros are python classes which subclass
-from rose.macro.MacroBase (api docs).
+from ``rose.macro.MacroBase`` (api docs).
 
-These macros implement their behaviours by providing a validate, transform or
-report method. A macro can contain any combination of these methods so, for
-example, a macro might be both a validator and a transformer.
+These macros implement their behaviours by providing a ``validate``,
+``transform`` or ``report`` method. A macro can contain any combination of
+these methods so, for example, a macro might be both a validator and a
+transformer.
 
-These methods should accept two rose.config.ConfigNode (api docs) instances
-as arguments - one is the configuration, and one is the metadata
+These methods should accept two ``rose.config.ConfigNode`` (api docs)
+instances as arguments - one is the configuration, and one is the metadata
 configuration that provides information about the configuration items.
 
 A validator macro should look like:
@@ -593,11 +603,11 @@ A validator macro should look like:
           # Some check on config appends to self.reports using self.add_report
           return self.reports
 
-The returned list should be a list of rose.macro.MacroReport objects
+The returned list should be a list of ``rose.macro.MacroReport`` objects
 containing the section, option, value, and warning strings for each setting
 that is in error. These are initialised behind the scenes by calling the
-inherited method rose.macro.MacroBase.add_report via self.add_report. This
-has the form:
+inherited method ``rose.macro.MacroBase.add_report`` via
+``self.add_report``. This has the form:
 
    .. code-block:: python
 
@@ -607,7 +617,7 @@ has the form:
 This means that you should call it with the relevant section first, then the
 relevant option, then the relevant value, then the relevant error message,
 and optionally a warning flag that we'll discuss later. If the setting is a
-section, the option should be None and the value None. For example,
+section, the option should be ``None`` and the value None. For example,
 
    .. code-block:: python
 
@@ -623,8 +633,8 @@ section, the option should be None and the value None. For example,
 Validator macros have the option to give warnings, which do not count as
 formal errors in the Rose config editor GUI. These should be used when
 something may be wrong, such as warning when using an advanced-developer-only
-option. They are invoked by passing a 5th argument to self.add_report,
-is_warning, like so:
+option. They are invoked by passing a 5th argument to ``self.add_report``,
+``is_warning``, like so:
 
    .. code-block:: python
 
@@ -651,8 +661,8 @@ A transformer macro should look like:
 The returned list should be a list of 4-tuples containing the section,
 option, value, and information strings for each setting that was changed
 (e.g. added, removed, value changed). If the setting is a section, the
-option should be None and the value None. If an option was removed, the
-value should be the old value - otherwise it should be the new one
+option should be ``None`` and the value None. If an option was removed,
+the value should be the old value - otherwise it should be the new one
 (added/changed). For example,
 
    .. code-block:: python
@@ -670,8 +680,8 @@ value should be the old value - otherwise it should be the new one
           return config, self.reports
 
 The current working directory within a macro is always the configuration's
-directory. This makes it easy to access non-rose-app.conf files (e.g. in the
-file/ subdirectory).
+directory. This makes it easy to access non-``rose-app.conf`` files (e.g.
+in the ``file/`` subdirectory).
 
 There are also reporter macros which can be used where you need to output
 some information about a configuration. A reporter macro takes the same form
@@ -691,7 +701,7 @@ as validator and transform macros but does not require a return value.
 Macros also support the use of keyword arguments, giving you the ability to
 have the user specify some input or override to your macro. For example a
 transformer macro could be written as follows to allow the user to input
-some_value:
+``some_value``:
 
    .. code-block:: python
 
@@ -699,8 +709,8 @@ some_value:
           """Some transformer macro"""
           return
 
-Note that the extra arguments require default values (=None in this example)
-and that you should add error handling for the input accordingly.
+Note that the extra arguments require default values (``=None`` in this
+example) and that you should add error handling for the input accordingly.
 
 On running your macro the user will be prompted to supply values for these
 arguments or accept the default values.
@@ -713,12 +723,12 @@ Rose upgrade macros are used to upgrade application configurations between
 metadata versions. They are classes, very similar to the Transform macros
 above, but with a few differences:
 
-* an upgrade method instead of a transform method
-* an optional downgrade method, identical in API to the upgrade method, but
-  intended for performing the reverse operation
-* a more helpful API via rose.upgrade.MacroUpgrade methods
-* BEFORE_TAG and AFTER_TAG attributes - the version of metadata they apply
-  to (BEFORE_TAG) and the version they upgrade to (AFTER_TAG)
+* an ``upgrade`` method instead of a ``transform`` method
+* an optional ``downgrade`` method, identical in API to the ``upgrade``
+  method, but intended for performing the reverse operation
+* a more helpful API via ``rose.upgrade.MacroUpgrade`` methods
+* ``BEFORE_TAG`` and ``AFTER_TAG`` attributes - the version of metadata they
+  apply to (``BEFORE_TAG``) and the version they upgrade to (``AFTER_TAG``)
 
 An example upgrade macro might look like this:
 
@@ -736,30 +746,31 @@ An example upgrade macro might look like this:
           self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
           return config, self.reports
 
-The class name is unimportant - the BEFORE_TAG and AFTER_TAG identify the
-macro.
+The class name is unimportant - the ``BEFORE_TAG`` and ``AFTER_TAG`` identify
+the macro.
 
-Metadata versions are usually structured in a rose-meta/CATEGORY/VERSION/
-hierarchy - where CATEGORY denotes the type or family of application
-(sometimes it is the command used), and VERSION is the particular version 
-e.g. 27.2 or HEAD.
+Metadata versions are usually structured in a ``rose-meta/CATEGORY/VERSION/``
+hierarchy - where ``CATEGORY`` denotes the type or family of application
+(sometimes it is the command used), and ``VERSION`` is the particular version 
+e.g. ``27.2`` or ``HEAD``.
 
-Upgrade macros live under the CATEGORY directory in a versions.py
-file - rose-meta/CATEGORY/versions.py.
+Upgrade macros live under the ``CATEGORY`` directory in a ``versions.py``
+file - ``rose-meta/CATEGORY/versions.py``.
 
 If you have many upgrade macros, you may want to separate them into different
-modules in the same directory. You can then import from those in versions.py,
-so that they are still exposed in that module. You'll need to make your
-directory a package by creating an __init__.py file, which should contain
-the line import versions. To avoid conflict with other CATEGORY upgrade
-modules (or other Python modules), please name these very modules carefully
-or use absolute or package level imports like this: from .versionXX_YY import
-FooBar.
+modules in the same directory. You can then import from those in
+``versions.py``, so that they are still exposed in that module. You'll need
+to make your directory a package by creating an ``__init__.py`` file, which
+should contain the line import versions. To avoid conflict with other
+``CATEGORY`` upgrade modules (or other Python modules), please name these
+very modules carefully or use absolute or package level imports like this:
+``from .versionXX_YY import FooBar``.
 
-Upgrade macros are subclasses of rose.upgrade.MacroUpgrade. They have all
+Upgrade macros are subclasses of ``rose.upgrade.MacroUpgrade``. They have all
 the functionality of the transform macros documented above.
-rose.upgrade.MacroUpgrade also has some additional convenience methods
-defined for you to call. All methods return None unless otherwise specified.
+``rose.upgrade.MacroUpgrade`` also has some additional convenience methods
+defined for you to call. All methods return ``None`` unless otherwise
+specified.
 
    .. TODO - something must be done
 
@@ -768,11 +779,11 @@ Rosie Web
 ---------
 
 This section explains how to use the Rosie web service API. All Rosie
-discovery services (e.g. rosie search, rosie go, web page) use a RESTful
-API to interrogate a web server, which then interrogates an RDBMS.
+discovery services (e.g. ``rosie search``, ``rosie go``, web page) use a
+RESTful API to interrogate a web server, which then interrogates an RDBMS.
 Returned data is encoded in the JSON format.
 
-You may wish to utilise the Python class rosie.ws_client.Client as an
+You may wish to utilise the Python class ``rosie.ws_client.Client`` as an
 alternative to this API.
 
 Location
@@ -780,11 +791,13 @@ Location
 
 The URLs to access the web API of a Rosie web service (with a given prefix
 name) can be found in your rose site configuration file as the value of
-[rosie-id]prefix-ws.PREFIX_NAME. To access the API for a given repository
-with prefix PREFIX_NAME, you must select a format (the only currently
+``[rosie-id]prefix-ws.PREFIX_NAME``. To access the API for a given repository
+with prefix ``PREFIX_NAME``, you must select a format (the only currently
 supported format is 'json') and use a url that looks like:
 
-http://host/PREFIX_NAME/get_known_keys?format=json
+   .. code-block:: none
+
+      http://host/PREFIX_NAME/get_known_keys?format=json
 
 Usage
 ^^^^^

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -93,7 +93,7 @@ This class should have a constructor of the form
 
           def __init__(self, value, metadata, set_value, hook, arg_str=None)
 
-with the following arguments
+with the following arguments:
 
 ``value``
   a string that represents the value that the widget should display.
@@ -383,7 +383,7 @@ The constructor arguments are
 Refreshing the whole page in order to display a small change to a variable
 (the default) can be undesirable. To deal with this, custom page widgets can
 optionally expose some variable-change specific methods that do this
-themselves. These take a single rose.variable.Variable instance as an
+themselves. These take a single ``rose.variable.Variable`` instance as an
 argument.
 
 ``def add_variable_widget(self, variable) -> None``
@@ -400,9 +400,9 @@ argument.
   nothing - e.g. one that contains just ``pass``).
 
 If you take the step of using your own variable widgets, rather than the
-VariableWidget class in ``lib/python/rose/config_editor/variable.py`` (the
-default for normal config-edit pages), each variable-specific widget should
-have an attribute ``variable`` set to their ``rose.variable.Variable``
+``VariableWidget`` class in ``lib/python/rose/config_editor/variable.py``
+(the default for normal config-edit pages), each variable-specific widget
+should have an attribute ``variable`` set to their ``rose.variable.Variable``
 instance. You can implement 'ignored' status display by giving the widget a
 method ``set_ignored`` which takes no arguments. This should examine the
 ``ignored_reason`` dictionary attribute of the widget's ``variable``
@@ -662,9 +662,9 @@ section, the option should be ``None`` and the value None. For example,
 
 Validator macros have the option to give warnings, which do not count as
 formal errors in the Rose config editor GUI. These should be used when
-something may be wrong, such as warning when using an advanced-developer-only
-option. They are invoked by passing a 5th argument to ``self.add_report``,
-``is_warning``, like so:
+something *may* be wrong, such as warning when using an
+advanced-developer-only option. They are invoked by passing a 5th argument
+to ``self.add_report``, ``is_warning``, like so:
 
    .. code-block:: python
 
@@ -793,7 +793,7 @@ If you have many upgrade macros, you may want to separate them into different
 modules in the same directory. You can then import from those in
 ``versions.py``, so that they are still exposed in that module. You'll need
 to make your directory a package by creating an ``__init__.py`` file, which
-should contain the line import versions. To avoid conflict with other
+should contain the line ``import versions``. To avoid conflict with other
 ``CATEGORY`` upgrade modules (or other Python modules), please name these
 very modules carefully or use absolute or package level imports like this:
 ``from .versionXX_YY import FooBar``.
@@ -834,16 +834,16 @@ supported format is 'json') and use a url that looks like:
 Usage
 ^^^^^
 
-.. TODO - complete/remove section
+.. TODO - complete/remove section as desired
 
 
 Rose Python Modules
 -------------------
 
-.. TODO - complete/remove section
+.. TODO - complete/remove section as desired
 
 
 Rose Bash Library
 -----------------
 
-.. TODO - complete/remove section
+.. TODO - complete/remove section as desired

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -47,10 +47,12 @@ or application. Widgets going into the Rose core should be added to the
 distribution.
 
 Example
+"""""""
 
 See the Advanced Tutorial.
 
 API Reference
+"""""""""""""
 
 All value widgets, custom or core, use the same API. This means that a good
 ractical reference is the set of existing value widgets in the package
@@ -245,6 +247,7 @@ You may even wish to do something off-the-wall such as an xdot-based widget
 set!
 
 API Reference
+"""""""""""""
 
 The procedure for generating a custom page widget is as follows:
 
@@ -426,6 +429,7 @@ Sub panels are capable of using quite a lot of functionality such as
 modifying the sections and options in the sub-pages directly.
 
 API Reference
+"""""""""""""
 
 The procedure for generating a custom sub panel widget is as follows:
 
@@ -567,15 +571,18 @@ Code
 ^^^^
 
 Examples
+""""""""
 
 See the macro Advanced Tutorial.
 
 API Documentation
+"""""""""""""""""
 
 The ``rose.macro.MacroBase`` class (subclassed by all rose macros) is
 documented here.
 
 API Reference
+"""""""""""""
 
 Validator, transformer and reporter macros are python classes which subclass
 from ``rose.macro.MacroBase`` (api docs).

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -77,10 +77,10 @@ The procedure for implementing a custom value widget is as follows:
 Assign a ``widget[rose-config-edit]`` attribute to the relevant variable in the
 metadata configuration, e.g.
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [namelist:VerifConNL/ScalarAreaCodes]
-      widget[rose-config-edit]=module_name.AreaCodeChooser
+   [namelist:VerifConNL/ScalarAreaCodes]
+   widget[rose-config-edit]=module_name.AreaCodeChooser
 
 where the widget class lives in the module ``module_name`` under
 ``lib/python/widget/`` in the metadata directory for the application or suite.
@@ -88,11 +88,11 @@ Modules are imported by the config editor on demand.
 
 This class should have a constructor of the form
 
-   .. code-block:: python
+.. code-block:: python
 
-      class AreaCodeChooser(gtk.HBox):
+   class AreaCodeChooser(gtk.HBox):
 
-          def __init__(self, value, metadata, set_value, hook, arg_str=None)
+       def __init__(self, value, metadata, set_value, hook, arg_str=None)
 
 with the following arguments:
 
@@ -276,20 +276,20 @@ The procedure for generating a custom page widget is as follows:
 Assign a ``widget`` option to the relevant namespace in the metadata
 configuration, e.g.
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [ns:namelist/STASHNUM]
-      widget[rose-config-edit]=module_name.MyGreatBigTable
+   [ns:namelist/STASHNUM]
+   widget[rose-config-edit]=module_name.MyGreatBigTable
 
 The widget class should have a constructor of the form
 
-   .. code-block:: python
+.. code-block:: python
 
-      class MyGreatBigTable(gtk.Table):
+   class MyGreatBigTable(gtk.Table):
 
-          def __init__(self, real_variable_list, missing_variable_list,
-                       variable_functions_inst, show_modes_dict,
-                       arg_str=None):
+       def __init__(self, real_variable_list, missing_variable_list,
+                    variable_functions_inst, show_modes_dict,
+                    arg_str=None):
 
 The class can inherit from any ``gtk.Container``\-derived class.
 
@@ -460,10 +460,10 @@ The procedure for generating a custom sub panel widget is as follows:
 Assign a ``widget[rose-config-edit:sub-ns]`` option to the relevant
 namespace in the metadata configuration, e.g.
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [ns:namelist/all_the_foo_namelists]
-      widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
+   [ns:namelist/all_the_foo_namelists]
+   widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
 
 Note that because the actual data on the page has a separate representation,
 you need to write ``[rose-config-edit:sub-ns]`` rather than just
@@ -471,14 +471,14 @@ you need to write ``[rose-config-edit:sub-ns]`` rather than just
 
 The widget class should have a constructor of the form
 
-   .. code-block:: python
+.. code-block:: python
 
-      class MySubPanelForFoos(gtk.VBox):
+   class MySubPanelForFoos(gtk.VBox):
 
-          def __init__(self, section_dict, variable_dict,
-                       section_functions_inst, variable_functions_inst,
-                       search_for_id_function, sub_functions_inst,
-                       is_duplicate_boolean, arg_str=None):
+       def __init__(self, section_dict, variable_dict,
+                    section_functions_inst, variable_functions_inst,
+                    search_for_id_function, sub_functions_inst,
+                    is_duplicate_boolean, arg_str=None):
 
 The class can inherit from any ``gtk.Container``\-derived class.
 
@@ -633,17 +633,17 @@ configuration that provides information about the configuration items.
 
 A validator macro should look like:
 
-   .. code-block:: python
+.. code-block:: python
 
-      import rose.macro
+   import rose.macro
 
-      class SomeValidator(rose.macro.MacroBase):
+   class SomeValidator(rose.macro.MacroBase):
 
-      """This does some kind of check."""
+   """This does some kind of check."""
 
-      def validate(self, config, meta_config=None):
-          # Some check on config appends to self.reports using self.add_report
-          return self.reports
+   def validate(self, config, meta_config=None):
+       # Some check on config appends to self.reports using self.add_report
+       return self.reports
 
 The returned list should be a list of ``rose.macro.MacroReport`` objects
 containing the section, option, value, and warning strings for each setting
@@ -651,26 +651,26 @@ that is in error. These are initialised behind the scenes by calling the
 inherited method ``rose.macro.MacroBase.add_report`` via
 ``self.add_report``. This has the form:
 
-   .. code-block:: python
+.. code-block:: python
 
-      def add_report(self, section=None, option=None, value=None, info=None,
-                   is_warning=False):
+   def add_report(self, section=None, option=None, value=None, info=None,
+                  is_warning=False):
 
 This means that you should call it with the relevant section first, then the
 relevant option, then the relevant value, then the relevant error message,
 and optionally a warning flag that we'll discuss later. If the setting is a
 section, the option should be ``None`` and the value None. For example,
 
-   .. code-block:: python
+.. code-block:: python
 
-      def validate(self, config, meta_config=None):
-          editor_value = config.get(["env", "MY_FAVOURITE_STREAM_EDITOR"]).value
-          if editor_value != "sed":
-              self.add_report("env",                         # Section
-                              "MY_FAVOURITE_STREAM_EDITOR",  # Option
-                              editor_value,                  # Value
-                              "Should be 'sed'!")            # Message
-          return self.reports
+   def validate(self, config, meta_config=None):
+       editor_value = config.get(["env", "MY_FAVOURITE_STREAM_EDITOR"]).value
+       if editor_value != "sed":
+           self.add_report("env",                         # Section
+                           "MY_FAVOURITE_STREAM_EDITOR",  # Option
+                           editor_value,                  # Value
+                           "Should be 'sed'!")            # Message
+       return self.reports
 
 Validator macros have the option to give warnings, which do not count as
 formal errors in the Rose config editor GUI. These should be used when
@@ -678,27 +678,27 @@ something *may* be wrong, such as warning when using an
 advanced-developer-only option. They are invoked by passing a 5th argument
 to ``self.add_report``, ``is_warning``, like so:
 
-   .. code-block:: python
+.. code-block:: python
 
-      self.add_report("env",
-                      "MY_FAVOURITE_STREAM_EDITOR",
-                      editor_value,
-                      "Could be 'sed'",
-                      is_warning=True)
+   self.add_report("env",
+                   "MY_FAVOURITE_STREAM_EDITOR",
+                   editor_value,
+                   "Could be 'sed'",
+                   is_warning=True)
 
 A transformer macro should look like:
 
-   .. code-block:: python
+.. code-block:: python
 
-      import rose.macro
+   import rose.macro
 
-      class SomeTransformer(rose.macro.MacroBase):
+   class SomeTransformer(rose.macro.MacroBase):
 
-      """This does some kind of change to the config."""
+   """This does some kind of change to the config."""
 
-      def transform(self, config, meta_config=None):
-          # Some operation on config which calls self.add_report for each change.
-          return config, self.reports
+   def transform(self, config, meta_config=None):
+       # Some operation on config which calls self.add_report for each change.
+       return config, self.reports
 
 The returned list should be a list of 4-tuples containing the section,
 option, value, and information strings for each setting that was changed
@@ -707,19 +707,19 @@ option should be ``None`` and the value None. If an option was removed,
 the value should be the old value - otherwise it should be the new one
 (added/changed). For example,
 
-   .. code-block:: python
+.. code-block:: python
 
-      def transform(self, config, meta_config=None):
-          """Add some more snow control."""
-          if config.get(["namelist:snowflakes"]) is None:
-              config.set(["namelist:snowflakes"])
-              self.add_report(list_of_changes,
-                              "namelist:snowflakes", None, None,
-                              "Updated snow handling in time for Christmas")
-              config.set(["namelist:snowflakes", "l_unique"], ".true.")
-              self.add_report("namelist:snowflakes", "l_unique", ".true.",
-                              "So far, anyway.")
-          return config, self.reports
+   def transform(self, config, meta_config=None):
+       """Add some more snow control."""
+       if config.get(["namelist:snowflakes"]) is None:
+           config.set(["namelist:snowflakes"])
+           self.add_report(list_of_changes,
+                           "namelist:snowflakes", None, None,
+                           "Updated snow handling in time for Christmas")
+           config.set(["namelist:snowflakes", "l_unique"], ".true.")
+           self.add_report("namelist:snowflakes", "l_unique", ".true.",
+                           "So far, anyway.")
+       return config, self.reports
 
 The current working directory within a macro is always the configuration's
 directory. This makes it easy to access non-``rose-app.conf`` files (e.g.
@@ -729,27 +729,27 @@ There are also reporter macros which can be used where you need to output
 some information about a configuration. A reporter macro takes the same form
 as validator and transform macros but does not require a return value.
 
-   .. code-block:: python
+.. code-block:: python
 
-       def report(self, config, meta_config=None):
-           """ Write some information about the configuration to a report file.
+   def report(self, config, meta_config=None):
+       """ Write some information about the configuration to a report file.
 
-           Note: report methods do not have a return value.
+       Note: report methods do not have a return value.
 
-           """
-           with open('report/file', 'r') as report_file:
-               report_file.write(str(config.get(["namelist:snowflakes"])))
+       """
+       with open('report/file', 'r') as report_file:
+           report_file.write(str(config.get(["namelist:snowflakes"])))
 
 Macros also support the use of keyword arguments, giving you the ability to
 have the user specify some input or override to your macro. For example a
 transformer macro could be written as follows to allow the user to input
 ``some_value``:
 
-   .. code-block:: python
+.. code-block:: python
 
-      def transform(self, config, meta_config=None, some_value=None):
-          """Some transformer macro"""
-          return
+   def transform(self, config, meta_config=None, some_value=None):
+       """Some transformer macro"""
+       return
 
 .. note::
    The extra arguments require default values (``=None`` in this
@@ -778,19 +778,19 @@ above, but with a few differences:
 
 An example upgrade macro might look like this:
 
-   .. code-block:: python
+.. code-block:: python
 
-      class Upgrade272to273(rose.upgrade.MacroUpgrade):
+   class Upgrade272to273(rose.upgrade.MacroUpgrade):
 
-      """Upgrade from 27.2 to 27.3."""
+   """Upgrade from 27.2 to 27.3."""
 
-      BEFORE_TAG = "27.2"
-      AFTER_TAG = "27.3"
+   BEFORE_TAG = "27.2"
+   AFTER_TAG = "27.3"
 
-      def upgrade(self, config, meta_config=None):
-          self.add_setting(config, ["env", "NEW_VARIABLE"], "0")
-          self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
-          return config, self.reports
+   def upgrade(self, config, meta_config=None):
+       self.add_setting(config, ["env", "NEW_VARIABLE"], "0")
+       self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
+       return config, self.reports
 
 .. note::
    The class name is unimportant - the ``BEFORE_TAG`` and ``AFTER_TAG``
@@ -843,9 +843,9 @@ name) can be found in your rose site configuration file as the value of
 with prefix ``PREFIX_NAME``, you must select a format (the only currently
 supported format is 'json') and use a url that looks like:
 
-   .. code-block:: none
+.. code-block:: none
 
-      http://host/PREFIX_NAME/get_known_keys?format=json
+   http://host/PREFIX_NAME/get_known_keys?format=json
 
 Usage
 ^^^^^

--- a/sphinx/user-guide/API.rst
+++ b/sphinx/user-guide/API.rst
@@ -1,0 +1,1332 @@
+API
+===
+
+
+Introduction
+------------
+
+Rose is mainly implemented in Python and bash.
+
+The sub-sections below explain how to make use of various application
+programming interfaces within Rose which are designed for extension. These
+are useful for extending Rose components or creating standalone programs that
+seek to manipulate Rose information.
+
+Most of these interfaces require a good knowledge of Python.
+
+
+Rose GTK library
+----------------
+
+The Rose/Rosie GUIs (such as the config editor) are written using the Python
+bindings for the GTK GUI toolkit (PyGTK). You can write your own custom GTK
+widgets and use them within Rose. They should live with the metadata under 
+the lib/python/widget/ directory.
+
+Value Widgets
+^^^^^^^^^^^^^
+
+Value widgets are used for operating on the values of settings. In the config
+editor, they appear next to the menu button and name label. There are builtin
+value widgets in Rose such as text entry boxes, radio buttons, and drop-down
+menus. These are chosen by the config editor based on metadata - for example,
+if a setting has an integer type, the value widget will be a spin button.
+
+The config editor supports adding user-defined custom widgets which replace
+the default widgets. These have the same API, but live in the metadata
+directories rather than the Rose source code.
+
+For example, you may wish to add widgets that deal with dates (e.g. using
+something based on a calendar widget) or use a slider widget for numbers.
+You may even want something that uses an image-based interface such as a
+latitude-longitude chooser based on a map.
+
+Normally, widgets will be placed within the metadata directory for the suite
+or application. Widgets going into the Rose core should be added to the
+lib/python/rose/config_editor/valuewidget/ directory in a Rose distribution.
+Example
+
+See the Advanced Tutorial.
+API Reference
+
+All value widgets, custom or core, use the same API. This means that a good
+ractical reference is the set of existing value widgets in the package
+rose.config_editor.valuewidget.
+
+The procedure for implementing a custom value widget is as follows:
+
+Assign a widget[rose-config-edit] attribute to the relevant variable in the
+metadata configuration, e.g.
+
+[namelist:VerifConNL/ScalarAreaCodes]
+widget[rose-config-edit]=module_name.AreaCodeChooser
+
+where the widget class lives in the module module_name under
+lib/python/widget/ in the metadata directory for the application or suite.
+Modules are imported by the config editor on demand.
+
+This class should have a constructor of the form
+
+class AreaCodeChooser(gtk.HBox):
+
+    def __init__(self, value, metadata, set_value, hook, arg_str=None)
+
+with the following arguments
+
+value
+    a string that represents the value that the widget should display.
+metadata
+
+    a map or dictionary of configuration metadata properties for this value,
+such as
+
+    {'type': 'integer', 'help': 'This is used to count something'}
+
+    You may not need to use this information.
+set_value
+
+    a function that should be called with a new string value of this widget,
+e.g.
+
+    set_value("20")
+
+hook
+
+    An instance of a class rose.config_editor.valuewidget.ValueWidgetHook
+containing callback functions that you should connect some of your widgets to.
+arg_str
+
+    a keyword argument that stores extra text given to the widget option in
+the metadata, if any:
+
+    widget[rose-config-edit]=modulename.ClassName arg1 arg2 arg3 ...
+
+    would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
+your widget - for example, for a table based widget, you might give the 
+column names
+    :
+
+    widget[rose-config-edit]=table.TableValueWidget NAME ID WEIGHTING
+
+    This means that you can write a generic widget and then configure it for
+different cases. 
+
+hook contains some callback functions that you should implement:
+
+hook.get_focus(widget) -> None
+
+    which you should connect your top-level widget (self) to as follows:
+
+        self.grab_focus = lambda: hook.get_focus(my_favourite_focus_widget)
+
+    or define a method in your class
+
+    def grab_focus(self):
+        """Override the focus method, so we can scroll to a particular
+widget."""
+        return hook.get_focus(my_favourite_focus_widget)
+
+    which allows the correct widget (my_favourite_focus_widget) in your
+container to receive the focus such as a gtk.Entry
+(my_favourite_focus_widget) and will also trigger a scroll action on a config
+editor page. This is important to implement to get the proper global find 
+functionality.
+hook.trigger_scroll(widget) -> None
+
+    accessed by
+
+        hook.trigger_scroll(my_favourite_focus_widget)
+
+    This should be connected to the focus-in-event GTK signal of your
+top-level widget (self):
+
+            self.entry.connect('focus-in-event',
+                               hook.trigger_scroll)
+
+    This also is used to trigger a config editor page scroll to your widget.
+
+You may implement the following optional methods for your widget, which help
+to preserve cursor position when a widget is refreshed:
+
+set_focus_index(focus_index) -> None
+
+    A method that takes a number as an argument, which is the current cursor
+position relative to the characters in the variable value:
+
+    def set_focus_index(self, focus_index):
+        """Set the cursor position to focus_index."""
+        self.entry.set_position(focus_index)
+
+    For example, a focus_index of 0 means that your widget should set the
+cursor position to the beginning of the value. A focus_index of 4 for a
+variable value of Operational means that the cursor should be placed between
+the r and the a.
+
+    This has no real meaning or importance for widgets that don't display
+editable text. If you do not supply this method, the config editor will
+attempt to do the right thing anyway.
+get_focus_index() -> focus_index
+
+    A method that takes no arguments and returns a number which is the
+current cursor position relative to the characters in the variable value:
+
+    def get_focus_index(self):
+        """Return the cursor position."""
+        return self.entry.get_position()
+
+    This has no real meaning or importance for widgets that don't display
+editable text. If you do not supply this method, the config editor will guess
+the cursor position anyway, based on the last change to the variable value.
+handle_type_error(is_in_error) -> None
+
+    The default behaviour when a variable error is added or removed is to
+re-instantiate the widget (refresh and redraw it). This can be overridden
+by defining this method in your value widget class. It takes a boolean
+is_in_error which is True if there is a value (type) error and False otherwise:
+
+    def handle_type_error(self, is_in_error):
+        """Change behaviour based on whether the variable is_in_error."""
+        icon_id = gtk.STOCK_DIALOG_ERROR if is_in_error else None
+        self.entry.set_icon_from_stock(0, gtk.STOCK_DIALOG_ERROR)
+
+    For example, this is used in a built-in widget for the quoted string
+types string and character. The quotes around the text are normally hidden,
+but the handle_type_error shows them if there is an error. The method also
+keeps the keyboard focus, which is the main purpose.
+
+    You may not have much need for this method, as the default error flagging
+and cursor focus handling is normally sufficient.
+
+All the existing variable value widgets are implemented using this API, so
+a good resource is the modules within the
+lib/python/rose/config_editor/valuewidget package.
+
+Config Editor Custom Pages
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A 'page' in the config editor is the container inside a tab or detached tab
+that (by default) contains a table of variable widgets. The config editor
+allows custom 'pages' to be defined that may or may not use the standard
+set of variable widgets (menu button, name, value widget). This allows any
+presentation of the underlying variable information.
+
+For example, you may wish to present the variables in a more structured,
+two-dimensional form rather than as a simple list. You may want to strip
+down or add to the information presented by default - e.g. hiding names or
+embedding widgets within a block of help text.
+
+You may even wish to do something off-the-wall such as an xdot-based widget
+set!
+API Reference
+
+The procedure for generating a custom page widget is as follows:
+
+Assign a widget option to the relevant namespace in the metadata
+configuration, e.g.
+
+    [ns:namelist/STASHNUM]
+    widget[rose-config-edit]=module_name.MyGreatBigTable
+
+The widget class should have a constructor of the form
+
+    class MyGreatBigTable(gtk.Table):
+
+        def __init__(self, real_variable_list, missing_variable_list,
+                     variable_functions_inst, show_modes_dict,
+                     arg_str=None):
+
+The class can inherit from any gtk.Container-derived class.
+
+The constructor arguments are
+
+real_variable_list
+    a list of the Variable objects (x.name, x.value, x.metadata, etc from
+the rose.variable module). These are the objects you will need to generate
+your widgets around.
+missing_variable_list
+    a list of 'missing' Variable objects that could be added to the container.
+You will only need to worry about these if you plan to show them by
+implementing the 'View Latent' menu functionality that we'll discuss
+further on.
+variable_functions_inst
+    an instance of the class
+rose.config_editor.ops.variable.VariableOperations.
+This contains methods to operate on the variables.
+These will update the undo stack and take care of any errors.
+These methods are the only ways that you should write to the variable states
+or values. For documentation, see the module
+lib/python/rose/config_editor/ops/variable.py.
+show_modes_dict
+    a dictionary that looks like this:
+
+        show_modes_dict = {'latent': False, 'fixed': False, 'ignored': True,
+                           'user-ignored': False, 'title': False,
+                           'flag:optional': False, 'flag:no-meta': False}
+
+    which could be ignored for most custom pages, as you need. The meaning of
+the different keys in a non-custom page is:
+
+    'latent'
+        False means don't display widgets for variables in the metadata or
+that have been deleted (the variable_list.ghosts variables)
+    'fixed'
+        False means don't display widgets for variables if they only have
+one value set in the metadata values option.
+    'ignored'
+        False means don't display widgets for variables if they're
+ignored (in the configuration, but commented out).
+    'user-ignored'
+        (If ignored is False) False means don't display widgets for
+user-ignored variables. True means always show user-ignored variables.
+    'title'
+        Short for 'View with no title', False means show the title of a
+variable, True means show the variable name instead.
+    'flag:optional'
+        True means indicate if a variable is optional, and False means do
+not show an indicator.
+    'flag:no-meta'
+        True means indicate if a variable has any metadata content, and
+False means do not show an indicator.
+
+    If you wish to implement actions based on changes in these properties
+(e.g. displaying and hiding fixed variables depending on the 'fixed'
+setting), the custom page widget should expose a method named
+'show_mode_change' followed by the key. However, 'ignored' is handled
+separately (more below). These methods should take a single boolean that
+indicates the display status. For example:
+
+    def show_fixed(self, should_show)
+
+    The argument should_show is a boolean. If True, fixed variables should
+be shown. If False, they should be hidden by your custom container.
+arg_str
+
+    a keyword argument that stores extra text given to the widget option
+in the metadata, if any:
+
+    widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
+
+    would give a arg_str of "arg1 arg2 arg3 ...". This could help configure
+your widget - for example, for a table based widget, you might give the
+column names
+    :
+
+    widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
+
+    This means that you can write a generic widget and then configure it
+for different cases. 
+
+Refreshing the whole page in order to display a small change to a variable
+(the default) can be undesirable. To deal with this, custom page widgets can
+optionally expose some variable-change specific methods that do this
+themselves. These take a single rose.variable.Variable instance as an argument.
+
+def add_variable_widget(self, variable) -> None
+    will be called when a variable is created.
+def reload_variable_widget(self, variable) -> None
+    will be called when a variable's status is changed, e.g. it goes into
+an error state.
+def remove_variable_widget(self, variable) -> None
+    will be called when a variable is removed.
+def update_ignored(self) -> None
+    will be called to allow you to update ignored widget display, if (for
+example) you show/hide ignored variables. If you don't have any custom
+behaviour for ignored variables, it's worth writing a method that does
+nothing - e.g. one that contains just pass).
+
+If you take the step of using your own variable widgets, rather than the
+VariableWidget class in lib/python/rose/config_editor/variable.py (the default
+for normal config-edit pages), each variable-specific widget should have an
+attribute variable set to their rose.variable.Variable instance. You can
+implement 'ignored' status display by giving the widget a method set_ignored
+which takes no arguments. This should examine the ignored_reason dictionary
+attribute of the widget's variable instance - the variable is ignored if
+this is not empty. If the variable is ignored, the widget should indicate
+this e.g. by greying out part of it.
+
+All existing page widgets use this API, so a good resource is the modules in
+lib/python/rose/config_editor/pagewidget/.
+
+Generally speaking, a visible change, click, or key press in the custom page
+widget should make instant changes to variable value(s), and the value that
+the user sees. Pages are treated as temporary, superficial views of variable
+data, and changes are always assumed to be made directly to the main copy
+of the configuration in memory (this is automatic when the
+rose.config_editor.ops.variable.VariableOperations methods are used, as
+they should be). Closing the page shouldn't change, or lose, any data!
+The custom class should return a gtk object to be packed into the page
+framework, so it's best to subclass from an existing gtk Container type
+such as gtk.VBox (or gtk.Table, in the example above).
+
+In line with the general philosophy, metadata should not be critical to
+page operations - it should be capable of displaying variables even when
+they have no or very little metadata, and still make sense if some
+variables are missing or new.
+
+Config Editor Custom Sub Panels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A 'sub panel' or 'summary panel' in the config editor is a panel that
+appears at the bottom of a page and is intended to display some summarised
+information about sub-pages (sub-namespaces) underneath the page. For
+example, the top-level file page, by default, has a sub panel to
+summarise the individual file sections.
+
+Any actual data belonging to the page will appear above the sub panel in a
+separate representation.
+
+Sub panels are capable of using quite a lot of functionality such as
+modifying the sections and options in the sub-pages directly.
+API Reference
+
+The procedure for generating a custom sub panel widget is as follows:
+
+Assign a widget[rose-config-edit:sub-ns] option to the relevant namespace
+in the metadata configuration, e.g.
+
+    [ns:namelist/all_the_foo_namelists]
+    widget[rose-config-edit:sub-ns]=module_name.MySubPanelForFoos
+
+Note that because the actual data on the page has a separate representation,
+you need to write [rose-config-edit:sub-ns] rather than just
+[rose-config-edit].
+
+The widget class should have a constructor of the form
+
+    class MySubPanelForFoos(gtk.VBox):
+
+        def __init__(self, section_dict, variable_dict,
+                     section_functions_inst, variable_functions_inst,
+                     search_for_id_function, sub_functions_inst,
+                     is_duplicate_boolean, arg_str=None):
+
+The class can inherit from any gtk.Container-derived class.
+
+The constructor arguments are:
+
+section_dict
+    a dictionary (map, hash) of section name keys and section data object
+values (instances of the rose.section.Section class). These contain some of
+the data such as section ignored status and comments that you may want to
+present. These objects can usually be used by the section_functions_inst
+methods as arguments - for example, passed in in order to ignore or enable
+a section.
+variable_dict
+    a dictionary (map, hash) of section name keys and lists of variable data
+objects (instances of the rose.variable.Variable class). These contain useful
+information for the variable (option) such as state, value, and comments.
+Like section data objects, these can usually be used as arguments to the
+variable_functions_inst methods to accomplish things like changing a variable
+value or adding or removing a variable.
+section_functions_inst
+    an instance of the class rose.config_editor.ops.section.SectionOperations.
+This contains methods to operate on the variables. These will update the undo
+stack and take care of any errors. Together with sub_functions_inst, these
+methods are the only ways that you should write to the section states or
+other attributes. For documentation, see the module
+lib/python/rose/config_editor/ops/section.py.
+variable_functions_inst
+    an instance of the class
+rose.config_editor.ops.variable.VariableOperations.
+This contains methods to operate on the variables. These will update the
+undo stack and take care of any errors. These methods are the only ways
+that you should write to the variable states or values. For documentation,
+see the module lib/python/rose/config_editor/ops/variable.py.
+search_for_id_function
+    a function that accepts a setting id (a section name, or a variable id)
+as an argument and asks the config editor to navigate to the page for that
+setting. You could use this to allow a click on a section name in your widget
+to launch the page for the section.
+sub_functions_inst
+    an instance of the class rose.config_editor.ops.group.SubDataOperations.
+This contains some convenience methods specifically for sub panels, such as
+operating on many sections at once in an optimised way. For documentation,
+see the module lib/python/rose/config_editor/ops/group.py.
+is_duplicate_boolean
+    a boolean that denotes whether or not the sub-namespaces in the summary
+data consist only of duplicate sections (e.g. only namelist:foo(1),
+namelist:foo(2), ...). For example, this could be used by your widget to
+decide whether to implement a "Copy section" user option.
+arg_str
+
+    a keyword argument that stores extra text given to the widget option
+in the metadata, if any - e.g.:
+
+    widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
+
+    would give a arg_str of "arg1 arg2 arg3 ...". You can use this to help 
+configure your widget.
+
+All existing sub panel widgets use this API, so a good resource is the
+modules in lib/python/rose/config_editor/panelwidget/.
+
+
+Rose Macros
+-----------
+
+Rose macros manipulate or check configurations, often based on their
+metadata. There are four types of macros:
+
+* Checkers (validators) - check a configuration, perhaps using metadata.
+* Changers (transformers) - change a configuration e.g. adding/removing
+  options.
+* Upgraders - these are special transformer macros for upgrading and
+  downgrading configurations. (covered in the Upgrade Macro API)
+* Reporters - output information about a configuration.
+
+There are built-in rose macros that handle standard behaviour such as trigger
+changing and type checking.
+
+This section explains how to add your own custom macros to transform and
+validate configurations. See Upgrade Macro API for upgrade macros.
+
+Macros use a Python API, and should be written in Python, unless you are
+doing something very fancy. In the absence of a Python house style, it's
+usual to follow the standard Python style guidance (PEP8, PEP257).
+
+They can be run within rose config-edit or via rose macro.
+
+You should avoid writing checker macros if the checking can be expressed via
+metadata.
+
+Location
+^^^^^^^^
+
+A module containing macros should be stored under a directory
+lib/python/macros/ in the metadata for a configuration. This directory should
+be a Python package.
+
+When developing macros for Rose internals, macros should be placed in the
+rose.macros package in the Rose Python library. They should be referenced by
+the lib/python/rose/macros/__init__.py classes and a call to them can be
+added in the lib/python/rose/config_editor/main.py module if they need to be
+run implicitly by the config editor.
+
+Code
+^^^^
+
+Examples
+
+See the macro Advanced Tutorial.
+API Documentation
+
+The rose.macro.MacroBase class (subclassed by all rose macros) is documented
+here.
+API Reference
+
+Validator, transformer and reporter macros are python classes which subclass
+from rose.macro.MacroBase (api docs).
+
+These macros implement their behaviours by providing a validate, transform or
+report method. A macro can contain any combination of these methods so, for
+example, a macro might be both a validator and a transformer.
+
+These methods should accept two rose.config.ConfigNode (api docs) instances
+as arguments - one is the configuration, and one is the metadata
+configuration that provides information about the configuration items.
+
+A validator macro should look like:
+
+import rose.macro
+
+class SomeValidator(rose.macro.MacroBase):
+
+    """This does some kind of check."""
+
+    def validate(self, config, meta_config=None):
+        # Some check on config appends to self.reports using self.add_report
+        return self.reports
+
+The returned list should be a list of rose.macro.MacroReport objects
+containing the section, option, value, and warning strings for each setting
+that is in error. These are initialised behind the scenes by calling the
+inherited method rose.macro.MacroBase.add_report via self.add_report. This
+has the form:
+
+    def add_report(self, section=None, option=None, value=None, info=None,
+                   is_warning=False):
+
+This means that you should call it with the relevant section first, then the
+relevant option, then the relevant value, then the relevant error message,
+and optionally a warning flag that we'll discuss later. If the setting is a
+section, the option should be None and the value None. For example,
+
+    def validate(self, config, meta_config=None):
+        editor_value = config.get(["env", "MY_FAVOURITE_STREAM_EDITOR"]).value
+        if editor_value != "sed":
+            self.add_report("env",                         # Section
+                            "MY_FAVOURITE_STREAM_EDITOR",  # Option
+                            editor_value,                  # Value
+                            "Should be 'sed'!")            # Message
+        return self.reports
+
+Validator macros have the option to give warnings, which do not count as
+formal errors in the Rose config editor GUI. These should be used when
+something may be wrong, such as warning when using an advanced-developer-only
+option. They are invoked by passing a 5th argument to self.add_report,
+is_warning, like so:
+
+            self.add_report("env",
+                            "MY_FAVOURITE_STREAM_EDITOR",
+                            editor_value,
+                            "Could be 'sed'",
+                            is_warning=True)
+
+A transformer macro should look like:
+
+import rose.macro
+
+class SomeTransformer(rose.macro.MacroBase):
+
+    """This does some kind of change to the config."""
+
+    def transform(self, config, meta_config=None):
+        # Some operation on config which calls self.add_report for each change.
+        return config, self.reports
+
+The returned list should be a list of 4-tuples containing the section,
+option, value, and information strings for each setting that was changed
+(e.g. added, removed, value changed). If the setting is a section, the
+option should be None and the value None. If an option was removed, the
+value should be the old value - otherwise it should be the new one
+(added/changed). For example,
+
+    def transform(self, config, meta_config=None):
+        """Add some more snow control."""
+        if config.get(["namelist:snowflakes"]) is None:
+            config.set(["namelist:snowflakes"])
+            self.add_report(list_of_changes,
+                            "namelist:snowflakes", None, None,
+                            "Updated snow handling in time for Christmas")
+            config.set(["namelist:snowflakes", "l_unique"], ".true.")
+            self.add_report("namelist:snowflakes", "l_unique", ".true.",
+                            "So far, anyway.")
+        return config, self.reports
+
+The current working directory within a macro is always the configuration's
+directory. This makes it easy to access non-rose-app.conf files (e.g. in the
+file/ subdirectory).
+
+There are also reporter macros which can be used where you need to output
+some information about a configuration. A reporter macro takes the same form
+as validator and transform macros but does not require a return value.
+
+    def report(self, config, meta_config=None):
+        """ Write some information about the configuration to a report file.
+
+        Note: report methods do not have a return value.
+
+        """
+        with open('report/file', 'r') as report_file:
+            report_file.write(str(config.get(["namelist:snowflakes"])))
+
+Macros also support the use of keyword arguments, giving you the ability to
+have the user specify some input or override to your macro. For example a
+transformer macro could be written as follows to allow the user to input
+some_value:
+
+    def transform(self, config, meta_config=None, some_value=None):
+        """Some transformer macro"""
+        return
+
+Note that the extra arguments require default values (=None in this example)
+and that you should add error handling for the input accordingly.
+
+On running your macro the user will be prompted to supply values for these
+arguments or accept the default values.
+
+
+Rose Upgrade Macros
+-------------------
+
+Rose upgrade macros are used to upgrade application configurations between
+metadata versions. They are classes, very similar to the Transform macros
+above, but with a few differences:
+
+* an upgrade method instead of a transform method
+* an optional downgrade method, identical in API to the upgrade method, but
+  intended for performing the reverse operation
+* a more helpful API via rose.upgrade.MacroUpgrade methods
+* BEFORE_TAG and AFTER_TAG attributes - the version of metadata they apply
+  to (BEFORE_TAG) and the version they upgrade to (AFTER_TAG)
+
+An example upgrade macro might look like this:
+
+class Upgrade272to273(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 27.2 to 27.3."""
+
+    BEFORE_TAG = "27.2"
+    AFTER_TAG = "27.3"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "NEW_VARIABLE"], "0")
+        self.remove_setting(config, ["namelist:old_things", "OLD_VARIABLE"])
+        return config, self.reports
+
+The class name is unimportant - the BEFORE_TAG and AFTER_TAG identify the
+macro.
+
+Metadata versions are usually structured in a rose-meta/CATEGORY/VERSION/
+hierarchy - where CATEGORY denotes the type or family of application
+(sometimes it is the command used), and VERSION is the particular version 
+e.g. 27.2 or HEAD.
+
+Upgrade macros live under the CATEGORY directory in a versions.py
+file - rose-meta/CATEGORY/versions.py.
+
+If you have many upgrade macros, you may want to separate them into different
+modules in the same directory. You can then import from those in versions.py,
+so that they are still exposed in that module. You'll need to make your
+directory a package by creating an __init__.py file, which should contain
+the line import versions. To avoid conflict with other CATEGORY upgrade
+modules (or other Python modules), please name these very modules carefully
+or use absolute or package level imports like this: from .versionXX_YY import
+FooBar.
+
+Upgrade macros are subclasses of rose.upgrade.MacroUpgrade. They have all
+the functionality of the transform macros documented above.
+rose.upgrade.MacroUpgrade also has some additional convenience methods
+defined for you to call. All methods return None unless otherwise specified.
+
+def act_from_files(self, config, downgrade=False)
+
+    A method that takes the app configuration (config, a
+rose.config.ConfigNode instance) and an optional boolean downgrade keyword
+argument. This initiates a search for etc/VERSION/rose-macro-add.conf and
+etc/VERSION/rose-macro-remove.conf, where VERSION is equal to the BEFORE_TAG
+of the macro. These files should be Rose app config-like patch files,
+containing settings to be added (rose-macro-add.conf) and settings to be
+removed (rose-macro-remove.conf). If downgrading (downgrade set to True),
+the settings in rose-macro-remove.conf will be added, and the ones in
+rose-macro-add.conf removed.
+
+        def upgrade(self, config, meta_config=None):
+            self.act_from_files(config)
+            return config, self.reports
+
+    Note that you can use other methods (below) as well as this in the
+same upgrade.
+
+    If settings are defined in either file, and changes can be made,
+the self.reports will be updated automatically.
+def add_setting(self, config, keys, value=None, forced=False, state=None,
+comments=None, info=None):
+
+    A method that attempts to add the setting defined by the list keys
+([section] or [section, option] strings) with the value value to the app
+config config. The arguments mostly follow rose.config.ConfigNode 
+attributes, and are as follows:
+
+    config
+        The application configuration object (rose.config.ConfigNode instance)
+    keys
+        A list of strings denoting config settings - [section_name] for a
+section, [section_name, option_name] for an option. For example, it might
+be ["namelist:foo", "bar"].
+    value (optional)
+        A string or None denoting the new setting value. None should be
+used for sections only. Options must have a string value defined.
+    forced (optional)
+        If the setting already exists, override the value to the new value.
+    state (optional)
+        Set the state of the new setting (rose.config.ConfigNode
+states) - None implies the default, which is
+rose.config.ConfigNode.STATE_NORMAL. You may also use
+rose.config.ConfigNode.STATE_USER_IGNORED.
+    comments (optional)
+        A list of comment strings (lines) for the new setting or None.
+    info (optional)
+        A short string containing no new lines, describing the addition of
+the setting.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.add_setting(config, ["namelist:breakfast_nl", "bacon"], "2",
+                             comments=["Mmmm. Bacon."], info="Add for
+food:#810")
+            return config, self.reports
+
+def change_setting_value(self, config, keys, value, forced=False,
+comments=None, info=None):
+
+    A method that attempts to change an existing setting value defined by
+keys to a new one (value) in the app config config. The arguments are:
+
+    config, keys, comments, info
+        As in add_setting above.
+    value
+        Required argument, must be a string for option values, and can be
+None for section values.
+    forced (optional)
+        Add the setting if it does not exist.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.change_setting_value(config, ["namelist:breakfast_nl",
+"coffee"], "'more'",
+                                      info="Add for food:#820")
+            return config, self.reports
+
+def get_setting_value(self, config, keys, no_ignore=False): (-> value)
+
+    A method that returns a setting value or None, functionally similar to
+rose.config.ConfigNode.get. The arguments are:
+
+    config, keys
+
+        As in add_setting above.
+    no_ignore (optional)
+        False means return the setting value if the setting is ignored. True
+means return None if the setting is ignored. If the setting is missing, None
+is returned.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            if self.get_setting_value(
+                        config, ["namelist:breakfast_nl", "coffee"]) == "'empty'":
+                self.add_setting(config, ["namelist:breakfast_nl", "tea"],
+                                 "'extra_strong'")
+            return config, self.reports
+
+def remove_setting(self, config, keys, info=None):
+
+    A method that removes a setting defined by keys in config with an
+optional info message. The arguments are:
+
+    config, keys, info
+        As in add_setting above.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.remove_setting(config, ["namelist:breakfast_nl", "cheeseburger"],
+                                info="Cheeseburgers are for lunch")
+            return config, self.reports
+
+    Example of removing an entire namelist:
+
+        def upgrade(self, config, meta_config=None):
+            self.remove_setting(config, ["namelist:breakfast_nl"],
+                                info="We don't serve breakfast anymore")
+            return config, self.reports
+
+def rename_setting(self, config, keys, new_keys, info=None):
+
+    A method that attempts to rename the setting defined by the list keys
+([section] or [section, option] strings) to the new name defined by new_keys.
+The arguments mostly follow rose.config.ConfigNode attributes, and are as
+follows:
+
+    config
+        The application configuration object (rose.config.ConfigNode instance)
+    keys
+        A list of strings denoting config settings - [section_name] for a
+section, [section_name, option_name] for an option. For example, it might be
+["namelist:foo", "bar_old"].
+    new_keys
+        A list of strings denoting config settings - [section_name] for a
+section, [section_name, option_name] for an option. For example, it might be
+["namelist:foo", "bar_new"].
+    info (optional)
+        A short string containing no new lines, describing the renaming of
+the setting.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.rename_setting(config, ["namelist:breakfast_nl", "bad_coffee"],
+                                ["namelist:breakfast_nl", "good_coffee"],
+                                info="Mmmm... nicer coffee...")
+            return config, self.reports
+
+def enable_setting(self, config, keys, info=None):
+
+    A method to make sure a setting defined by keys in config is not
+user-ignored. The arguments are:
+
+    config, keys, info
+        As in add_setting above.
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.enable_setting(config, ["namelist:breakfast_nl", "egg_monitoring"])
+            return config, self.reports
+
+def ignore_setting(self, config, keys, info=None, state=rose.config.ConfigNode.STATE_USER_IGNORED):
+
+    Inverse of enable_setting, a method to make sure a setting defined by
+keys in config is ignored (default state is user-ignored). The arguments are:
+
+    config, keys, info
+        As in add_setting above.
+    state
+        One of rose.config.ConfigNode.STATE_USER_IGNORED (default),
+rose.config.ConfigNode.STATE_SYST_IGNORED (trigger-ignored). When using it,
+you can just use config.STATE... rather than the full
+rose.config.ConfigNode.STATE....
+
+    Example usage:
+
+        def upgrade(self, config, meta_config=None):
+            self.ignore_setting(config, ["namelist:breakfast_nl", "milk_bottle_date"])
+            return config, self.reports
+
+There is an upgrade macro development tutorial and more examples in the
+upgrade file for the upgrade usage tutorial (versions.py), at
+$ROSE_HOME/etc/rose-meta/rose-demo-upgrade/versions.py, where $ROSE_HOME
+is the path to your local Rose distribution, locatable by invoking rose
+--version.
+
+
+Rosie Web
+---------
+
+This section explains how to use the Rosie web service API. All Rosie
+discovery services (e.g. rosie search, rosie go, web page) use a RESTful
+API to interrogate a web server, which then interrogates an RDBMS.
+Returned data is encoded in the JSON format.
+
+You may wish to utilise the Python class rosie.ws_client.Client as an
+alternative to this API.
+
+Location
+^^^^^^^^
+
+The URLs to access the web API of a Rosie web service (with a given prefix
+name) can be found in your rose site configuration file as the value of
+[rosie-id]prefix-ws.PREFIX_NAME. To access the API for a given repository
+with prefix PREFIX_NAME, you must select a format (the only currently
+supported format is 'json') and use a url that looks like:
+
+http://host/PREFIX_NAME/get_known_keys?format=json
+
+Usage
+^^^^^
+
+The API contains the following methods:
+
+get_known_keys
+    returns the main property names stored for suites (e.g. idx, branch,
+owner) plus any additional names specified in the site config and takes
+the format argument. For example, entering a URL in a web browser:
+
+    http://host/PREFIX_NAME/get_known_keys?format=json
+
+    may give
+
+    ["access-list", "idx", "branch", "owner", "project", "revision",
+"status",  "title"]
+
+get_optional_keys
+    returns all unique optional or user-defined property names given in
+suite discovery information and takes the format argument. For example,
+entering this URL in Firefox:
+
+    http://host/PREFIX_NAME/get_optional_keys?format=json
+
+    may give
+
+    ["access-list", "description", "endgame_status", "operational_flag",
+"tag-list"]
+
+get_query_operators
+    returns all the SQL-like operators used to compare column values that
+you may use in queries (below) (e.g. eq, ne, contains, like) and takes the
+format argument. For example, entering this URL in a web browser:
+
+    http://host/PREFIX_NAME/get_query_operators?format=json
+
+    may give
+
+    ["eq", "ge", "gt", "le", "lt", "ne", "contains", "endswith", "ilike",
+"like", "match", "startswith"]
+
+query
+    takes a list of queries q and the format argument. The syntax of the
+query looks like:
+
+    CONJUNCTION+[OPEN_GROUP+]FIELD+OPERATOR+VALUE[+CLOSE_GROUP]
+
+    where
+
+    CONJUNCTION
+        and or or
+    OPEN_GROUP
+        optional, one or more (
+    FIELD
+        e.g. idx or description
+    OPERATOR
+        e.g. contains or between, one of the operators returned by
+get_query_operators
+    VALUE
+        e.g. euro4m or 200
+    CLOSE_GROUP
+        optional, one or more )
+
+    The first CONJUNCTION is technically superfluous. The OPEN_GROUP and
+CLOSE_GROUP do not have to be used. Entering this URL in a web browser:
+
+    http://host/PREFIX_NAME/query?q=and+idx+endswith+78&q=or+owner+eq+bob&format=json
+
+    may give
+
+    [{"idx": "mo1-aa078", "branch": "trunk", "revision": 200, "owner": "fred",
+      "project": "fred's project.", "title": "fred's awesome suite",
+      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"},
+     {"idx": "mo1-aa090", "branch": "trunk", "revision": 350, "owner": "bob",
+      "project": "var", "title": "A copy of var.vexcs.", "status": "M ",
+      "access-list": ["*"], "operational": "Y"}]
+
+    This returned all current suites that have an idx that ends with 78 and
+also all suites that have the owner bob. Each suite is returned as an entry
+in a list - each entry is an associative array of property name-value pairs.
+These pairs contain all database information about a suite.
+
+    query also takes the optional argument all_revs which switches on
+searching older revisions of current suites and deleted suites. For example,
+entering this URL in a web browser:
+
+    http://host/mo1/json/query?q=and+idx+endswith+78&all_revs&format=json
+
+    may give
+
+    [{"idx": "mo1-aa078", "branch": "trunk", "revision": 120, "owner": "fred",
+      "project": "fred's project.", "title": "fred's new suite",
+      "status": "A "}
+     {"idx": "mo1-aa078", "branch": "trunk", "revision": 199, "owner": "fred",
+      "project": "fred's project.", "title": "fred's awesome suite",
+      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"},
+     {"idx": "mo1-aa078", "branch": "trunk", "revision": 200, "owner": "fred",
+      "project": "fred's project.", "title": "fred's awesome suite",
+      "status": "M ", "access-list": ["fred", "jack"], "description": "awesome"}]
+
+    This returned all past and present suites that have an idx that ends
+with 78. You can see that older revisions of the aa078 suite appear.
+
+    You can also use parentheses in your search to group expressions. For
+example, entering this URL in a web browser:
+
+    http://host/PREFIX_NAME/query?q=and+(+owner+eq+bob&q=or+owner+eq+fred+)&q=and+project+eq+test&format=json
+
+    would search for all suites that are owned by bob or fred that have the
+project test.
+search
+    takes any number of string arguments and the format argument and returns
+a list of matching suites with properties in the same format as query. The
+suite database is searched for suites with any property with a value that
+contains any of the string arguments. For example, entering this URL in a
+web browser:
+
+    http://host/PREFIX_NAME/search?var+bob+nowcast&format=json
+
+    may give
+
+    [{"idx": "mo1-aa090", "branch": "trunk", "revision": 330, "owner": "bob",
+      "project": "um", "title": "A copy of um.alpra.", "status": "M ",
+      "description": "Bob's UM suite"},
+     {"idx": "mo1-aa092", "branch": "trunk", "revision": 340, "owner": "jim",
+      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
+      "location": "NAE"},
+     {"idx": "mo1-aa100", "branch": "trunk", "revision": 352, "owner": "ops_account",
+      "project": "nowcast", "title": "The operational Nowcast suite",
+      "status": "M ", "ensemble": "yes"}]
+
+    This returned all suites that contain one or more of these search terms.
+Each suite is returned as an entry in a list, and each entry is an
+associative array of suite property name-value pairs. These pairs contain
+all database information about a suite.
+
+    search also takes the optional argument all_revs in the same way as
+query, above. This switches on searching older revisions of current suites
+and deleted suites. For example, entering this URL in a web browser:
+
+    http://host/PREFIX_NAME/search?var+bob&all_revs&format=json
+
+    may give
+
+    [{"idx": "mo1-aa001", "branch": "trunk", "revision": 120, "owner": "bob",
+      "project": "useless", "title": "Bob's useless suite.", "status": "A "},
+     {"idx": "mo1-aa001", "branch": "trunk", "revision": 122, "owner": "bob",
+      "project": "useless", "title": "Bob's useless suite.", "status": "D "},
+     {"idx": "mo1-aa090", "branch": "trunk", "revision": 320, "owner": "bob",
+      "project": "um", "title": "A copy of um.alpra.", "status": "A "},
+     {"idx": "mo1-aa090", "branch": "trunk", "revision": 321, "owner": "bob",
+      "project": "um", "title": "A copy of um.alpra.", "status": "M "},
+     {"idx": "mo1-aa090", "branch": "trunk", "revision": 330, "owner": "bob",
+      "project": "um", "title": "A copy of um.alpra.", "status": "M "},
+     {"idx": "mo1-aa092", "branch": "trunk", "revision": 335, "owner": "jim",
+      "project": "var", "title": "6D Quantum VAR.", "status": "A "},
+     {"idx": "mo1-aa092", "branch": "trunk", "revision": 338, "owner": "jim",
+      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
+      "location": "Africa"},
+     {"idx": "mo1-aa092", "branch": "trunk", "revision": 340, "owner": "jim",
+      "project": "var", "title": "6D Quantum VAR.", "status": "M ",
+      "location": "NAE"}]
+
+    This returned all past and present suites that contained a match for at
+least one of the search terms. Older versions of suites appear, and you can
+also see a deleted suite (aa001).
+
+
+Rose Python Modules
+-------------------
+
+This gives some brief information about Rose python modules. For more
+information, see the files themselves.
+
+Rose Main Modules
+^^^^^^^^^^^^^^^^^
+
+This section describes the modules under the lib/python/rose package.
+
+rose
+    (__init__.py) stores some constants used by Rose programs.
+rose.app_run
+    callable, Rose application runner.
+rose.apps.*
+    (package) built-in Rose applications.
+rose.bush
+    callable, Rose Bush services logic.
+rose.c3
+    library, implements the C3 algorithm (e.g. to linearise multiple
+inheritance).
+rose.checksum
+    library, determine the MD5 checksum for a file or files in a directory.
+rose.config
+    library, parses and dumps rose configuration files. Contains the main
+configuration object rose.config.ConfigNode which is manipulated in most
+rose programs.
+rose.config_cli
+    callable, implements the rose config command.
+rose.config_dump
+    callable, implements the rose config-dump command.
+rose.config_editor/*
+    (package) Rose configuration editor logic. See Rose Config Editor Modules.
+rose.config_processor
+    library, base class for rose configuration processing.
+rose.config_processors
+    (package) subclasses for rose configuration processing.
+rose.config_tree
+    library, representation of a Rose configruation directory.
+rose.date
+    callable, implements the rose date command. Contains date shift library.
+rose.env
+    library, handles environment variable substitution.
+rose.env_cat
+    callable, implements rose env-cat command.
+rose.external
+    library, contains minimal wrapper functions for calling external programs.
+rose.formats
+    (package) contains modules that deal with supported format parsing. The
+only current supported format is Fortran namelist, through
+rose.formats.namelist.
+rose.fs_util
+    library, file system utilities with event reporting.
+rose.gtk
+    (package) contains modules that deal with generic GTK operations and
+contain shared widgets.
+rose.host_select
+    callable, ranks and selects host machines.
+rose.job_runner
+    library, run jobs with multiple processes.
+rose.macro
+    callable, runs internal and custom macros for an application or suite.
+rose.macros
+    (package) Built-in macros. See Rose Build-in Macro Modules.
+rose.meta_type
+    library, classes for the various metadata type groups.
+rose.meta_type
+    library, data types in a Rose configuration metadata.
+rose.metadata_check
+    callable, validates configuration metadata.
+rose.metadata_gen
+    callable, generates template metadata for an application.
+rose.metadata_graph
+    callable, implement the rose metadata-graph command.
+rose.namelist_dump
+    callable, dumps namelist files to a Rose configuration object.
+rose.opt_parse
+    library, contains an optparse.OptionParser subclass. All command-line
+option parsing in Rose should use this.
+rose.popen
+    library, utilities for spawning and monitoring processes.
+rose.resource
+    library, locates files or directories.
+rose.run
+    library, base class for application, suite and task runners.
+rose.run_source_vc
+    library, functions to print out version control information for rose
+suite-run.
+rose.scheme_handler
+    library, logic to load python modules based on named schemes.
+rose.section
+    library, contains section-specific data utilities. Counterpart of
+rose.variable.
+rose.stem
+    callable, converts user-friendly options for testing code into options
+for rose suite-run.
+rose.suite_clean
+    callable, remove runtime directories of suites.
+rose.suite_control
+    Invoke control commands (currently gcontrol and shutdown) of a running
+suite.
+rose.suite_engine_proc
+    library, base class and utilities for interacting with a suite engine.
+rose.suite_engine_procs
+    (package) library for interacting with specific suite engines.
+rose.suite_hook
+    callable, hooks to suite engine events.
+rose.suite_log
+    callable, implements the rose suite-log command.
+rose.suite_restart
+    callable, implements the rose suite-restart command.
+rose.suite_run
+    callable, suite runner.
+rose.suite_scan
+    callable, scans for running suites.
+rose.task_env
+    callable, provides an environment for a suite task.
+rose.task_run
+    callable, task runner.
+rose.upgrade
+    library, provides configuration upgrade functionality.
+rose.variable
+    library, utilities for processing metadata and a basic data structure
+used by the config editor to hold values and metadata for options.
+rose.ws
+    library, logic for web services, e.g. Rose Bush and Rosie Disco.
+
+Rose Config Editor Modules
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This section describes the modules under the lib/python/rose/config_editor
+package. These are specific to the config editor.
+
+rose.config_editor
+    (__init__.py) stores some constants used for display in the config editor.
+All of these can be overridden using your user config.
+rose.config_editor.keywidget, rose.config_editor.menuwidget,
+rose.config_editor.pagewidget (package), rose.config_editor.variable,
+rose.config_editor.valuewidget (package)
+    These contain GTK code that control the adding/removing/modifying of
+options on a config editor tab. These can all be overridden using custom
+widgets (especially rose.config_editor.valuewidget modules).
+rose.config_editor.loader
+    This controls the loading and retrieval of configuration data within the
+config editor.
+rose.config_editor.main
+    This contains the centralised main control code of the config
+editor - updates, undo stack, etc.
+rose.config_editor.menu
+    This module contains the menu for the config editor and various
+menu-related functions such as adding and removing sections.
+rose.config_editor.page
+    This module contains control code for each config editor tab, and
+interfaces with rose.config_editor.pagewidget objects (including custom
+pages).
+rose.config_editor.panel
+    This creates and alters the GTK Treeview panel of the config editor.
+rose.config_editor.stack
+    This holds the Undo and Redo stack templates, and contains various
+functions to alter variables. This is the main functional interface for 
+custom pages.
+rose.config_editor.util
+    Various small utilities.
+rose.config_editor.window
+    Creates the main GTK window of the config editor and provides functions
+to launch dialogs.
+
+Rose Built-in Macro Modules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The lib/python/rose/macros package contains built-in macros that perform
+checking against metadata. Most of these are run each time something changes
+in the config editor. They can be run on the command line via rose macro.
+
+rose.macros.compulsory
+    checks/fixes compulsory sections and options
+rose.macros.format
+    checks format-specific sections and options, using options in
+rose.formats modules
+rose.macros.rule
+    checks fail-if and warn-if metadata conditions
+rose.macros.trigger
+    checks trigger validity and transforms configuration ignored states
+rose.macros.value
+    checks type, range, length, pattern, or values metadata
+
+Rosie Modules
+^^^^^^^^^^^^^
+
+This section describes the modules under the lib/python/rosie package.
+
+rosie.browser
+    (package) GTK client code for rosie (rosie go).
+rosie.browser.history
+    Methods and classes for recording suite search history. Used by rosie go.
+rosie.browser.main
+    Main control code for rosie go.
+rosie.browser.result
+    Custom widget with methods for displaying suite search results. Used by
+rosie go.
+rosie.browser.status
+    Classes for getting and updating statuses for checked out suites. Used by
+rosie go.
+rosie.browser.suite
+    Contains a wrapper class for handling the creation, copying, checking out
+and deleting of suites. Used by rosie go.
+rosie.browser.util
+    Library of widgets for rosie.browser.
+rosie.db
+    Interface code to the suite database, called by the web server.
+rosie.db_create
+    Callable, implements rosa db-create command.
+rosie.graph
+    Callable, implements rosie graph command.
+rosie.suite_id
+    Callable, implements the rosie id command to identify suites.
+rosie.svn_post_commit
+    Callable, implements the rosa svn-post-commit command.
+rosie.svn_pre_commit
+    Callable, implements the rosa svn-pre-commit command.
+rosie.usertools.*
+    (package) logic shared by rosa svn-post-commit and rosa svn-pre-commit for
+accessing user information, e.g. from Unix password file or LDAP.
+rosie.vc
+    Callable, implements wrappers to version control system.
+rosie.ws
+    Callable, Rosie Discovery service (Rosie Disco).
+rosie.ws_client
+    Library, Rosie Disco clients.
+rosie.ws_client_auth
+    Library, Rosie Disco client authentication schemes and keyring
+management.
+rosie.ws_client_cli
+    Callable, Rosie Disco CLI clients.
+
+
+Rose Bash Library
+-----------------
+
+They live under lib/bash/. Each module contains a set of functions. To import
+a module, load the file into your script. E.g. To load rose_usage, you would
+do:
+
+. $ROSE_HOME/lib/bash/rose_usage
+
+The modules are:
+
+rose_init
+    Called by rose on initialisation. This is not meant to be a module for
+general use.
+rose_log
+    Provide functions to print log messages.
+rose_usage
+    If your script has a header similar to the ones used by a Rose command
+line utility, you can use this function to print the synopsis section of the
+script header.

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -407,8 +407,7 @@ fail-if, warn-if
 
   .. code-block:: rose
 
-     fail-if=this != 1 + namelist:test=ctrl_var_1 *
-     (namelist:test=ctrl_var_2 - this);
+     fail-if=this != 1 + namelist:test=ctrl_var_1 * (namelist:test=ctrl_var_2 - this);
 
   shows a more complex operation, again with numeric values.
 
@@ -1082,7 +1081,7 @@ and an expression in the configuration metadata:
 
 then the expression would become:
 
-   .. code-block:: rose
+   .. code-block:: none
 
       'peaceful' != 'annoyed' and 2 >= 2
 

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -71,31 +71,37 @@ configuration and files if found.
 For example, you might have a rose-meta directory that contains the following
 files and directories:
 
-cheese_sandwich/
-    vn1.5/
-        rose-meta.conf
-    vn2.0/
-        rose-meta.conf
-cheese/
-    vn1.0/
-        rose-meta.conf
+   .. code-block:: none
+
+      cheese_sandwich/
+          vn1.5/
+              rose-meta.conf
+          vn2.0/
+              rose-meta.conf
+      cheese/
+          vn1.0/
+              rose-meta.conf
 
 and write an app referencing this rose-meta directory that looks like this:
 
-meta=cheese_sandwich/vn2.0
+   .. code-block:: rose
 
-[env]
-CHEESE=camembert
-SANDWICH_BREAD=brown
+     meta=cheese_sandwich/vn2.0
+
+     [env]
+     CHEESE=camembert
+     SANDWICH_BREAD=brown
 
 This will reference the metadata at rose-meta/cheese_sandwich/vn2.0.
 
 Now, we can write the rose-meta.conf file using an import:
 
-import=cheese/vn1.0
+   .. code-block:: rose
 
-[env=SANDWICH_BREAD]
-values=white,brown,seeded
+      import=cheese/vn1.0
+
+      [env=SANDWICH_BREAD]
+      values=white,brown,seeded
 
 which will inherit metadata from metadata from
 rose-meta/cheese/vn1.0/rose-meta.conf.
@@ -145,18 +151,20 @@ setting_sort_key, null string will be used.
 
     For example, the following metadata:
 
-    [env=apple]
+   .. code-block:: rose
 
-    [env=banana]
+      [env=apple]
 
-    [env=cherry]
-    sort-key=favourites-01
+      [env=banana]
 
-    [env=melon]
-    sort-key=do-not-like-01
+      [env=cherry]
+      sort-key=favourites-01
 
-    [env=prune]
-    sort-key=do-not-like-00
+      [env=melon]
+      sort-key=do-not-like-01
+
+      [env=prune]
+      sort-key=do-not-like-00
 
     would produce a sorting order of env=prune, env=melon, env=cherry,
 env=apple, env=banana.
@@ -295,9 +303,11 @@ should contain the same number of elements as the values entry.
 
     For example, given the following metadata:
 
-    [env=HEAT]
-    values=0, 1, 2
-    value-titles=low, medium, high
+   .. code-block:: rose
+
+      [env=HEAT]
+      values=0, 1, 2
+      value-titles=low, medium, high
 
     the config editor will display low for option value 0, medium for 1 and
 high for 2.
@@ -309,8 +319,10 @@ is like an auto-complete widget.
 
     For example, given the following metadata:
 
-    [env=suggested_fruit]
-    value-hints=pineapple,cherry,banana,apple,pear,mango,kiwi,grapes,peach,fig,
+   .. code-block:: rose
+
+      [env=suggested_fruit]
+      value-hints=pineapple,cherry,banana,apple,pear,mango,kiwi,grapes,peach,fig,
                =orange,strawberry,blackberry,blackcurrent,raspberry,melon,plum
 
     the config editor will display possible option values when the user
@@ -336,8 +348,10 @@ syntax) to compare against the whole value of the setting.
 
     For example, if we write the following metadata:
 
-    [namelist:cheese=country_of_origin]
-    pattern=^"[A-Z].+"$
+   .. code-block:: rose
+
+      [namelist:cheese=country_of_origin]
+      pattern=^"[A-Z].+"$
 
     then we expect all valid values for country_of_origin to start with a
 double quote (^"), begin with an uppercase letter ([A-Z]), contain some other
@@ -350,9 +364,11 @@ expression that repeats and includes commas. For example, if each element in
 our TARTAN_PAINT_COLOURS array must obey the regular expression 'red'|'blue',
 then we can write:
 
-    [env=TARTAN_PAINT_COLOURS]
-    length=:
-    pattern=^('red'|'blue')(?:,('red'|'blue'))*$
+   .. code-block:: rose
+
+      [env=TARTAN_PAINT_COLOURS]
+      length=:
+      pattern=^('red'|'blue')(?:,('red'|'blue'))*$
 
 fail-if, warn-if
 
@@ -365,36 +381,48 @@ will only issue a warning. The logical expression uses a Python-like syntax
 setting with the this variable and the value of other settings with their IDs.
 E.g.:
 
-    [namelist:test=my_test_var]
-    fail-if=this < namelist:test=control_lt_var;
+   .. code-block:: rose
+
+      [namelist:test=my_test_var]
+      fail-if=this < namelist:test=control_lt_var;
 
     means that an error will be flagged if the numeric value of my_test_var
 is less than the numeric value of control_lt_var.
 
-    fail-if=this != 1 + namelist:test=ctrl_var_1 *
-(namelist:test=ctrl_var_2 - this);
+   .. code-block:: rose
+
+      fail-if=this != 1 + namelist:test=ctrl_var_1 *
+      (namelist:test=ctrl_var_2 - this);
 
     shows a more complex operation, again with numeric values.
 
     To check array elements, the ID should be expressed with a bracketed
 index, as in the configuration:
 
-    fail-if=this(2) != "'0A'" and this(4) == "'0A'";
+   .. code-block:: rose
+
+      fail-if=this(2) != "'0A'" and this(4) == "'0A'";
 
     Array elements can also be checked using any and all. E.g.:
 
-    fail-if=any(namelist:test=ctrl_array < this);
-    fail-if=all(this == 0);
+   .. code-block:: rose
+
+      fail-if=any(namelist:test=ctrl_array < this);
+      fail-if=all(this == 0);
 
     Similarly, the number of array elements can be checked using len. E.g.:
 
-    fail-if=len(namelist:test=ctrl_array) < this;
-    fail-if=len(this) == 0;
+   .. code-block:: rose
+
+      fail-if=len(namelist:test=ctrl_array) < this;
+      fail-if=len(this) == 0;
 
     Expressions can be chained together and brackets used:
 
-    fail-if=this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or
-namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
+   .. code-block:: rose
+
+      fail-if=this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or
+      namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
 
     Multiple failure conditions can be added, by using a semicolon as the
 separator - the semicolon is optional for a single statement or the last in a
@@ -402,26 +430,34 @@ block, but is recommended. Multiple failure conditions are essentially similar
 to chaining them together with or, but the system can process each expression
 one by one to target the error message.
 
-    fail-if=this > 0; this % 2 == 1; this * 3 > 100;
+   .. code-block:: rose
+
+      fail-if=this > 0; this % 2 == 1; this * 3 > 100;
 
     You can add a message to the error or warning message to make it clearer
 by adding a hash followed by the comment at the end of a configuration
 metadata line:
 
-    fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common
+   .. code-block:: rose
+
+      fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common
 divisor for ctrl_array
 
     When using multiple failure conditions, different messages can be added
 if they are placed on individual lines:
 
-    fail-if=this > 0; # Needs to be less than or equal to 0
-            this % 2 == 1; # Needs to be odd
-            this * 3 > 100; # Needs to be more than 100/3.
+   .. code-block:: rose
+
+      fail-if=this > 0; # Needs to be less than or equal to 0
+              this % 2 == 1; # Needs to be odd
+              this * 3 > 100; # Needs to be more than 100/3.
 
     A slightly different usage of this functionality can do things like
 warn of deprecated content:
 
-    warn-if=True;  # This option is deprecated
+   .. code-block:: rose
+
+      warn-if=True;  # This option is deprecated
 
     This would always evaluate True and give a warning if the setting is
 present.
@@ -483,12 +519,14 @@ separated).
 
     The trigger syntax looks like:
 
-    [namelist:trig_nl=trigger_variable]
-    trigger=namelist:dep_nl=A;
-            namelist:dep_nl=B;
-            namelist:value_nl=X: 10;
-            env=Y: 20, 30, 40;
-            namelist:value_nl=Z: 20;
+   .. code-block:: rose
+
+      [namelist:trig_nl=trigger_variable]
+      trigger=namelist:dep_nl=A;
+              namelist:dep_nl=B;
+              namelist:value_nl=X: 10;
+              env=Y: 20, 30, 40;
+              namelist:value_nl=Z: 20;
 
     In this example:
 
@@ -518,11 +556,13 @@ loads a configuration. Triggering thereafter will work as normal.
 if all triggers are active (i.e. an AND relationship). For example, for
 the two triggers here:
 
-    [env=IS_WATER]
-    trigger=env=IS_ICE: true;
+   .. code-block:: rose
 
-    [env=IS_COLD]
-    trigger=env=IS_ICE: true;
+      [env=IS_WATER]
+      trigger=env=IS_ICE: true;
+
+      [env=IS_COLD]
+      trigger=env=IS_ICE: true;
 
     the setting env=IS_ICE is only enabled if both env=IS_WATER and
 env=IS_COLD are true and enabled. Otherwise, it is ignored.
@@ -531,9 +571,11 @@ env=IS_COLD are true and enabled. Otherwise, it is ignored.
 metadata mini-language, in the same way as the range or fail-if metadata.
 As with range, inter-variable comparisons are disallowed.
 
-    [env=SNOWFLAKE_SIDES]
-    trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
-            env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
+   .. code-block:: rose
+
+      [env=SNOWFLAKE_SIDES]
+      trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
+              env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
 
     In this example, the setting env=CUSTOM_SNOWFLAKE_GEOMETRY is enabled
 if env=SNOWFLAKE_SIDES is enabled and not 6. env=SILLY_SNOWFLAKE_GEOMETRY is
@@ -558,14 +600,18 @@ upgrade macros).
     E.g. for a macro class called FibonacciChecker in the metadata under
 lib/python/macros/fib.py, we may have:
 
-    macro=fib.FibonacciChecker
+   .. code-block:: rose
+
+      macro=fib.FibonacciChecker
 
     This may be used in the config editor to visually associate the setting
 with these macros. If a macro class has both a transform and a validate
 method, you can specify which you need by appending the method to the name
 e.g.:
 
-    macro=fib.Fibonacci.validate
+   .. code-block:: rose
+
+      macro=fib.Fibonacci.validate
 
 widget[gui-application]
 
@@ -579,36 +625,46 @@ point real number.
 after the widget name. E.g. to set up a hypothetical table with named columns
 X, Y, VCT, and Level, we may do:
 
-    widget[rose-config-edit]=table.TableWidget X Y VCT Level
+   .. code-block:: rose
+
+      widget[rose-config-edit]=table.TableWidget X Y VCT Level
 
     You may override to a Rose built-in widget by specifying a full rose
 class path in Python - for example, to always show radiobuttons for an option
 with values set:
 
-    widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
+   .. code-block:: rose
+
+      widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
 
     Another useful Rose built-in widget to use is the array element aligning
 page widget, rose.config_editor.pagewidget.table.PageArrayTable. You can set
 this for a section or namespace to make sure each nth variable value element
 lines up horizontally. For example:
 
-    [namelist:meal_choices]
-    customers='Athos','Porthos','Aramis','d''Artagnan'
-    entrees='soup','pate','soup','asparagus'
-    main='beef','spaghetti','coq au vin','lamb'
-    petits_fours=.false.,.true.,.false.,.true.
+   .. code-block:: rose
+
+      [namelist:meal_choices]
+      customers='Athos','Porthos','Aramis','d''Artagnan'
+      entrees='soup','pate','soup','asparagus'
+      main='beef','spaghetti','coq au vin','lamb'
+      petits_fours=.false.,.true.,.false.,.true.
 
     could use the following metadata:
 
-    [namelist:meal_choices]
-    widget[rose-config-edit]=rose.config_editor.pagewidget.table.PageArrayTable
+   .. code-block:: rose
+
+      [namelist:meal_choices]
+      widget[rose-config-edit]=rose.config_editor.pagewidget.table.PageArrayTable
 
     to align the elements on the page like this:
 
-    customers        Athos      Porthos      Aramis      d'Artagnan
-    entrees          soup        pate         soup       asparagus
-    main             beef      spaghetti   coq au vin       lamb
-    petits_fours    .false.     .true.       .false.       .true.
+   .. code-block:: none
+
+      customers        Athos      Porthos      Aramis      d'Artagnan
+      entrees          soup        pate         soup       asparagus
+      main             beef      spaghetti   coq au vin       lamb
+      petits_fours    .false.     .true.       .false.       .true.
 
 copy-mode (metadata usage with the rose-suite.info file)
 
@@ -617,14 +673,18 @@ never copied or copied with any value associated to be clear.
 
     For example: in a rose-suite.info file
 
-    [ensemble members]
-    copy-mode=never
+   .. code-block:: rose
+
+      [ensemble members]
+      copy-mode=never
 
     Setting the ensemble members field to include copy-mode=never means
 that the ensemble members field would never be copied.
 
-    [additional info]
-    copy-mode=clear
+   .. code-block:: rose
+
+      [additional info]
+      copy-mode=clear
 
     Setting the additional info field to include copy-mode=never means that
 the additional info field would be copied, but any value associated with it
@@ -639,18 +699,22 @@ url
 
     A web URL containing help for the setting. For example:
 
-    url=http://www.something.com/FOO/view/dev/doc/FOO.html
+   .. code-block:: rose
+
+      url=http://www.something.com/FOO/view/dev/doc/FOO.html
 
     For example, the config editor will trigger a web browser to display this
 when a variable name is clicked. A partial URL can be used for variables if
 the variable's section or namespace has a relevant parent url property to use
 as a prefix. For example:
 
-    [namelist:foo]
-    url=https://www.google.com/search
+   .. code-block:: rose
 
-    [namelist:foo=bar]
-    url=?q=nearest+bar
+      [namelist:foo]
+      url=https://www.google.com/search
+
+      [namelist:foo=bar]
+      url=?q=nearest+bar
 
 help
 
@@ -659,7 +723,9 @@ this in a popup dialog for a variable. Embedding variable ids in the help
 string will allow links to the variables to be created within the popup
 dialog box, e.g.
 
-    help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test
+   .. code-block:: rose
+
+      help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test
 to do something linear.
 
     Web URLs beginning with http:// will also be presented as links in the
@@ -699,9 +765,11 @@ Each of the above settings can be a colon-separated list of paths.
 Underneath each directory in the search path should be a hierarchy like the
 following:
 
-${APP}/HEAD/
-${APP}/${VERSION}/
-${APP}/versions.py # i.e. the upgrade macros
+   .. code-block:: bash
+
+      ${APP}/HEAD/
+      ${APP}/${VERSION}/
+      ${APP}/versions.py # i.e. the upgrade macros
 
 N.B. A Rose suite info is likely to have no versions.
 
@@ -718,35 +786,43 @@ directories.
 For example, a system CHOCOLATE may have a flat metadata structure within
 the repository:
 
-CHOCOLATE/doc/
-...
-CHOCOLATE/rose-meta/
-CHOCOLATE/rose-meta/choc-dark/
-CHOCOLATE/rose-meta/choc-milk/
+   .. code-block:: bash
+
+      CHOCOLATE/doc/
+      ...
+      CHOCOLATE/rose-meta/
+      CHOCOLATE/rose-meta/choc-dark/
+      CHOCOLATE/rose-meta/choc-milk/
     
 
 and the system CAFFEINE may have a hybrid structure, with both flat and 
 hierarchical components:
 
-CAFFEINE/doc/
-...
-CAFFEINE/rose-meta/caffeine-guarana/
-CAFFEINE/rose-meta/caffeine-coffee/cappuccino/
-CAFFEINE/rose-meta/caffeine-coffee/latte/
-CAFFEINE/rose-meta/caffeine-tea/yorkshire/
-CAFFEINE/rose-meta/caffeine-tea/lapsang/
+   .. code-block:: rose
+
+      CAFFEINE/doc/
+      ...
+      CAFFEINE/rose-meta/caffeine-guarana/
+      CAFFEINE/rose-meta/caffeine-coffee/cappuccino/
+      CAFFEINE/rose-meta/caffeine-coffee/latte/
+      CAFFEINE/rose-meta/caffeine-tea/yorkshire/
+      CAFFEINE/rose-meta/caffeine-tea/lapsang/
 
 and a site configuration with:
 
-meta-path=/path/to/rose-meta
+   .. code-block:: rose
+
+      meta-path=/path/to/rose-meta
 
 We would expect the following directories in /path/to/rose-meta:
 
-/path/to/rose-meta/caffeine-guarana/
-/path/to/rose-meta/caffeine-coffee/
-/path/to/rose-meta/caffeine-tea/
-/path/to/rose-meta/choc-dark/
-/path/to/rose-meta/choc-milk/
+   .. code-block:: bash
+
+      /path/to/rose-meta/caffeine-guarana/
+      /path/to/rose-meta/caffeine-coffee/
+      /path/to/rose-meta/caffeine-tea/
+      /path/to/rose-meta/choc-dark/
+      /path/to/rose-meta/choc-milk/
 
 with caffeine-coffee containing subdirectories cappuccino and latte, and
 caffeine-tea containing yorkshire and lapsang
@@ -790,19 +866,21 @@ application configuration.
 Application configurations can reference the configuration metadata as
 follows:
 
-#!cfg
-# Refer to the HEAD version
-# (typically you wouldn't do this since no upgrade process is possible)
-# For flat metadata
-meta=my-command
-# For hierarchical metadata
-meta=/path/to/metadata/my-command/HEAD
+   .. code-block:: rose
 
-# Refer to a named or tagged version in the flat metadata
-meta=my-command/8.3
-meta=my-command/t123
-# Refer to a named or tagged version in the hierarchical metadata
-meta=/path/to/metadata/my-command/8.3
+      #!cfg
+      # Refer to the HEAD version
+      # (typically you wouldn't do this since no upgrade process is possible)
+      # For flat metadata
+      meta=my-command
+      # For hierarchical metadata
+      meta=/path/to/metadata/my-command/HEAD
+
+      # Refer to a named or tagged version in the flat metadata
+      meta=my-command/8.3
+      meta=my-command/t123
+      # Refer to a named or tagged version in the hierarchical metadata
+      meta=/path/to/metadata/my-command/8.3
 
 If a version is defined then the Rose utilities will first look for the
 corresponding named version. If this cannot be found then the HEAD version
@@ -894,46 +972,53 @@ Operators
 
 The following numeric operators are supported:
 
-+     # add
--     # subtract
-*     # multiply
-**    # power or exponent - e.g. 2 ** 3 implies 8
-/     # divide
-//    # integer divide (floor) - e.g. 3 // 2 implies 1
-%     # remainder e.g. 5 % 3 implies 2
+   .. code-block:: rose
+
+      +     # add
+      -     # subtract
+      *     # multiply
+      **    # power or exponent - e.g. 2 ** 3 implies 8
+      /     # divide
+      //    # integer divide (floor) - e.g. 3 // 2 implies 1
+      %     # remainder e.g. 5 % 3 implies 2
 
 The following string operators are supported:
 
-+      # concatenate - e.g. "foo" + "bar" implies "foobar"
-*      # self-concatenate some number of times - e.g. "foo" * 2 implies
-         "foofoo"
-%      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
-in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
-not in # opposite sense of in
+   .. code-block:: rose
 
-# Where m, n are integers or expressions that evaluate to integers
-# (negative numbers count from the end of the string):
-[n]   # get nth character from string - e.g. "foo"[1] implies "o"
-[m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
-[m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies
+      +      # concatenate - e.g. "foo" + "bar" implies "foobar"
+      *      # self-concatenate some number of times - e.g. "foo" * 2 implies "foofoo"
+      %      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
+      in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
+      not in # opposite sense of in
+
+      # Where m, n are integers or expressions that evaluate to integers
+      # (negative numbers count from the end of the string):
+      [n]   # get nth character from string - e.g. "foo"[1] implies "o"
+      [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
+      [m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies
         "oobar"
-[:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
+      [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
 
 The following logical operators are supported:
 
-and   # Logical AND
-or    # Logical OR
-not   # Logical NOT
+   .. code-block:: rose
+
+      and   # Logical AND
+      or    # Logical OR
+      not   # Logical NOT
 
 The following comparison operators are supported:
 
-is    # Is the same object as (usually used for 'is none')
-<     # Less than
->     # Greater than
-==    # Equal to
->=    # Greater than or equal to
-<=    # Less than or equal to
-!=    # Not equal to
+   .. code-block:: rose
+
+      is    # Is the same object as (usually used for 'is none')
+      <     # Less than
+      >     # Greater than
+      ==    # Equal to
+      >=    # Greater than or equal to
+      <=    # Less than or equal to
+      !=    # Not equal to
 
 Operator precedence is intended to be the same as Python. However, with the
 current choice of language engine, the % and // operators may not obey
@@ -944,9 +1029,11 @@ Constants
 
 The following are special constants:
 
-None  # Python None
-False # Python False
-True  # Python True
+   .. code-block:: rose
+
+      None  # Python None
+      False # Python False
+      True  # Python True
 
 Using Variable Ids
 ^^^^^^^^^^^^^^^^^^
@@ -957,17 +1044,23 @@ the expression.
 
 For example, if we have a configuration that looks like this:
 
-[namelist:zoo]
-num_elephants=2
-elephant_mood='peaceful'
+   .. code-block:: rose
+
+      [namelist:zoo]
+      num_elephants=2
+      elephant_mood='peaceful'
 
 and an expression in the configuration metadata:
 
-namelist:zoo=elephant_mood != 'annoyed' and num_elephants >= 2
+   .. code-block:: rose
+
+      namelist:zoo=elephant_mood != 'annoyed' and num_elephants >= 2
 
 then the expression would become:
 
-'peaceful' != 'annoyed' and 2 >= 2
+   .. code-block:: rose
+
+      'peaceful' != 'annoyed' and 2 >= 2
 
 If the variable is not currently available (ignored or missing) then the
 expression cannot be evaluated. If inter-variable comparisons are not allowed
@@ -979,13 +1072,17 @@ In this case the expression would be false.
 You may use this as a placeholder for the current variable id - for example,
 the fail-if expression:
 
-[namelist:foo=bar]
-fail-if=namelist:foo=bar > 100 and namelist:foo=bar % 2 == 1
+   .. code-block:: rose
+
+      [namelist:foo=bar]
+      fail-if=namelist:foo=bar > 100 and namelist:foo=bar % 2 == 1
 
 is the same as:
 
-[namelist:foo=bar]
-fail-if=this > 100 and this % 2 == 1
+   .. code-block:: rose
+
+      [namelist:foo=bar]
+      fail-if=this > 100 and this % 2 == 1
 
 Arrays
 ^^^^^^
@@ -996,7 +1093,9 @@ arrays - i.e. comma-separated lists.
 You can refer to a single element of the value for a given variable id
 (or this) by suffixing a number in round brackets - e.g.:
 
-namelist:foo=bar(2)
+   .. code-block:: none
+
+      namelist:foo=bar(2)
 
 references the second element in the value for bar in the section
 namelist:foo. This follows Fortran index numbering and syntax, which starts
@@ -1005,27 +1104,37 @@ written as foo(1).
 
 If we had a configuration:
 
-[namelist:foo]
-bar='a', 'b', 'c', 'd'
+   .. code-block:: rose
+
+      [namelist:foo]
+      bar='a', 'b', 'c', 'd'
 
 namelist:foo=bar(2) would get substituted in an expression with 'b' when the
 expression was evaluated. For example, an expression that contained:
 
-namelist:foo=bar(2) == 'c'
+   .. code-block:: none
+
+      namelist:foo=bar(2) == 'c'
 
 would be evaluated as:
 
-'b' == 'c'
+   .. code-block:: none
+
+      'b' == 'c'
 
 Should you wish to make use of the array length in an expression you can
 make use of the len function, which behaves in the same manner as its
 Python and Fortran equivalents to return the array length. For example:
 
-len(namelist:foo=bar) > 3
+   .. code-block:: none
+
+      len(namelist:foo=bar) > 3
 
 would be expanded to:
 
-4 > 3
+   .. code-block:: none
+
+      4 > 3
 
 and evaluate as true.
 
@@ -1036,22 +1145,30 @@ different syntax.
 They allow you to write a shorthand expression within an any() or all()
 bracket which implies a loop over each array element. For example:
 
-any(namelist:foo=bar == 'e')
+   .. code-block:: none
+
+      any(namelist:foo=bar == 'e')
 
 evaluates true if any elements in the value of bar in the section
 namelist:foo are 'e'. For the above configuration snippet, this would be
 expanded before evaluation to be:
 
-'a' == 'e' or 'b' == 'e' or 'c' == 'e' or 'd' == 'e'
+   .. code-block:: none
+
+      'a' == 'e' or 'b' == 'e' or 'c' == 'e' or 'd' == 'e'
 
 Similarly,
 
-all(namelist:foo=bar == 'e')
+   .. code-block:: none
+
+      all(namelist:foo=bar == 'e')
 
 evaluates true if all elements are 'e'. Again, with the above configuration,
 this would be expanded before proper evaluation:
 
-'a' == 'e' and 'b' == 'e' and 'c' == 'e' and 'd' == 'e'
+   .. code-block:: none
+
+      'a' == 'e' and 'b' == 'e' and 'c' == 'e' and 'd' == 'e'
 
 Internals
 ^^^^^^^^^

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -10,67 +10,69 @@ See Configuration Format.
 A configuration metadata is itself a configuration. Each configuration
 metadata is represented in a directory with the following:
 
-* rose-meta.conf, the main configuration file. See for detail.
-* opt/ directory. For detail, see Optional Configuration.
+* ``rose-meta.conf``, the main configuration file. See for detail.
+* ``opt/`` directory. For detail, see Optional Configuration.
 * other files, e.g.:
 
-  * lib/python/widget/my_widget.py would be the location of a custom widget.
-  * lib/python/macros/my_macro_validator.py would be the location of a custom
-    macro.
-  * etc/ would contain any resources for the logics in lib/python/, such
-    as an icon for the custom widget.
+  * ``lib/python/widget/my_widget.py`` would be the location of a custom
+    widget.
+  * ``lib/python/macros/my_macro_validator.py`` would be the location of a
+    custom macro.
+  * ``etc/`` would contain any resources for the logics in ``lib/python/``,
+    such as an icon for the custom widget.
 
 Rose utilities will do a path search for metadata using the following in order
 of precedence:
 
-* Configuration metadata embedded in the meta/ directory of a suite or an
+* Configuration metadata embedded in the ``meta/`` directory of a suite or an
   application.
-* The --meta-path=PATH option of relevant commands.
-* The value of the ROSE_META_PATH environment variable.
-* The meta-path setting in site/user configurations.
+* The ``--meta-path=PATH`` option of relevant commands.
+* The value of the ``ROSE_META_PATH`` environment variable.
+* The ``meta-path`` setting in site/user configurations.
 
 See Metadata Location for more details.
 
 The configuration metadata that controls default behaviour will be located in
-$ROSE_HOME/etc/rose-meta/.
+``$ROSE_HOME/etc/rose-meta/``.
 
 
 Configuration Metadata File
 ---------------------------
 
-The rose-meta.conf contains a serialised data structure that is an unordered
-map (sections=) of unordered maps (keys=values).
+The ``rose-meta.conf`` contains a serialised data structure that is an
+unordered map (``sections=``) of unordered maps (``keys=values``).
 
-The section name in a configuration metadata file should be a unique ID to the
-relevant configuration setting. The syntax of the ID is
-SECTION-NAME=OPTION-NAME or just SECTION-NAME. For example, env=MY_ENV_NAME is
-the ID of an environment variable called MY_ENV_NAME in an application
-configuration file; namelist:something_nl=variable_name1 is the ID of a
-namelist variable called variable_name1 in a namelist group called
-something_nl in an application configuration file. If the configuration
+The section name in a configuration metadata file should be a unique ID to
+the relevant configuration setting. The syntax of the ID is
+``SECTION-NAME=OPTION-NAME`` or just ``SECTION-NAME``. For example,
+``env=MY_ENV_NAME`` is the ID of an environment variable called
+``MY_ENV_NAME`` in an application configuration file;
+``namelist:something_nl=variable_name1`` is the ID of a
+namelist variable called ``variable_name1`` in a namelist group called
+``something_nl`` in an application configuration file. If the configuration
 metadata applies to a section in a configuration file, the ID is just the
 section name.
 
 Where multiple instances of a section are used in a configuration file,
 ending in brackets with numbers, the metadata id should just be based on the
-original section name (for example namelist:extract_control(2) should be
-found in the metadata under namelist:extract_control).
+original section name (for example ``namelist:extract_control(2)`` should be
+found in the metadata under ``namelist:extract_control``).
 
 Finally, the configuration metadata may group settings in namespaces, which
 may in turn have common configuration metadata settings. The ID for a
-namespace set in the metadata is ns=NAME, e.g.
-ns=env/MyFavouriteEnvironmentVars.
+namespace set in the metadata is ``ns=NAME``, e.g.
+``ns=env/MyFavouriteEnvironmentVars``.
 
 Metadata Inheritance (Import)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A root level import=MY_COMMAND1/VERSION1 MY_COMMAND2/VERSION2 ... setting in
-the rose-meta.conf file will tell Rose metadata utilities to locate the meta
-keys MY_COMMAND1/VERSION1, MY_COMMAND2/VERSION2 (and so on) and inherit their
-configuration and files if found.
+A root level ``import=MY_COMMAND1/VERSION1 MY_COMMAND2/VERSION2 ...`` setting
+in the ``rose-meta.conf`` file will tell Rose metadata utilities to locate
+the meta keys ``MY_COMMAND1/VERSION1``, ``MY_COMMAND2/VERSION2`` (and so on)
+and inherit their configuration and files if found.
 
-For example, you might have a rose-meta directory that contains the following
-files and directories:
+For example, you might have a ``rose-meta`` directory that contains the
+following files and directories:
 
    .. code-block:: none
 
@@ -83,7 +85,8 @@ files and directories:
           vn1.0/
               rose-meta.conf
 
-and write an app referencing this rose-meta directory that looks like this:
+and write an app referencing this ``rose-meta`` directory that looks like
+this:
 
    .. code-block:: rose
 
@@ -93,9 +96,9 @@ and write an app referencing this rose-meta directory that looks like this:
      CHEESE=camembert
      SANDWICH_BREAD=brown
 
-This will reference the metadata at rose-meta/cheese_sandwich/vn2.0.
+This will reference the metadata at ``rose-meta/cheese_sandwich/vn2.0``.
 
-Now, we can write the rose-meta.conf file using an import:
+Now, we can write the ``rose-meta.conf`` file using an import:
 
    .. code-block:: rose
 
@@ -105,7 +108,7 @@ Now, we can write the rose-meta.conf file using an import:
       values=white,brown,seeded
 
 which will inherit metadata from metadata from
-rose-meta/cheese/vn1.0/rose-meta.conf.
+``rose-meta/cheese/vn1.0/rose-meta.conf``.
 
 Metadata Options
 ^^^^^^^^^^^^^^^^
@@ -120,17 +123,17 @@ These configuration metadata are used for grouping and sorting the IDs of
 the configurations.
 
 ns
-  A forward slash / delimited hierarchical namespace for the container of
+  A forward slash ``/`` delimited hierarchical namespace for the container of
   the setting, which overrides the default. The default namespace for the
   setting is derived from the first part of the ID - by splitting up the
-  section name by colons : or forward slashes /. For example, a configuration
-  with an ID namelist:var_minimise=niter_set would have the namespace
-  namelist/var_minimise. If a namespace is defined for a section, it will
-  become the default for all the settings in that section.
+  section name by colons ``:`` or forward slashes ``/``. For example, a
+  configuration with an ID ``namelist:var_minimise=niter_set`` would have
+  the namespace ``namelist/var_minimise``. If a namespace is defined for a
+  section, it will become the default for all the settings in that section.
 
   The namespace is used by the config editor to group settings, so that
-  they can be placed in different pages. A namespace for a section will become
-  the default for all the settings in that section.
+  they can be placed in different pages. A namespace for a section will
+  become the default for all the settings in that section.
 
   Note that you should not assign namespaces to variables in duplicate
   sections.
@@ -146,8 +149,8 @@ sort-key
   without a sort-key will be sorted after, in ascending order of their IDs.
 
   The sorting procedure in pseudo code is a normal ASCII-like sorting of a
-  list of setting_sort_key + "~" + setting_id strings. If there is no
-  setting_sort_key, null string will be used.
+  list of ``setting_sort_key + "~" + setting_id`` strings. If there is no
+  ``setting_sort_key``, null string will be used.
 
   For example, the following metadata:
 
@@ -166,8 +169,8 @@ sort-key
      [env=prune]
      sort-key=do-not-like-00
 
-  would produce a sorting order of env=prune, env=melon, env=cherry,
-  env=apple, env=banana.
+  would produce a sorting order of ``env=prune``, ``env=melon``,
+  ``env=cherry``, ``env=apple``, ``env=banana``.
 
 Metadata for Values
 ^^^^^^^^^^^^^^^^^^^
@@ -180,98 +183,100 @@ metadata will normally be ignored.
 
 type
   The type/class of the setting. The type names are based on the intrinsic
-  Fortran types, such as integer and real. Currently supported types are:
+  Fortran types, such as ``integer`` and ``real``. Currently supported types
+  are:
 
-  boolean
-    example option: PRODUCE_THINGS=true
+  ``boolean``
+    *example option*: ``PRODUCE_THINGS=true``
 
-    description: either true or false
+    *description*: either ``true`` or ``false``
 
-    usage: environment variables, javascript/JSON inputs
+    *usage*: environment variables, javascript/JSON inputs
 
-  character
-    example option: sea_colour='blue'
+  ``character``
+    *example option*: ``sea_colour='blue'``
 
-    description: Fortran character type - a single quoted string, single
+    *description*: Fortran character type - a single quoted string, single
     quotes escaped in pairs
 
-    usage: Fortran character types
+    *usage*: Fortran character types
 
-  integer
-    example option: num_lucky=5
+  ``integer``
+    *example option*: ``num_lucky=5``
 
-    description: generic integer type
+    *description*: generic integer type
 
-    usage: any integer-type input
+    *usage*: any integer-type input
 
-  logical
-    example option: l_spock=.true.
+  ``logical``
+    *example option*: ``l_spock=.true.``
 
-    description: Fortran logical type - either .true. or .false.
+    *description*: Fortran logical type - either ``.true.`` or ``.false.``
 
-    usage: Fortran logical types
+    *usage*: Fortran logical types
 
-  python_boolean
-    example option: ENABLE_THINGS=True
+  ``python_boolean``
+    *example option*: ``ENABLE_THINGS=True``
 
-    description: Python boolean type - either True or False
+    *description*: Python boolean type - either ``True`` or ``False``
 
-    usage: Python boolean types
+    *usage*: Python boolean types
 
-  python_list
-    description: used to signify a Python-compatible formatted list such
-    as ["Foo", 50, False]. This encapsulates length, so do not use a separate
-    length declaration for this setting.
+  ``python_list``
+    *description*: used to signify a Python-compatible formatted list such
+    as ``["Foo", 50, False]``. This encapsulates ``length``, so do not use a
+    separate ``length`` declaration for this setting.
 
-    usage: use for inputs that expect a string that looks like a Python
+    *usage*: use for inputs that expect a string that looks like a Python
     list - e.g. Jinja2 list input variables.
 
-  quoted
-    example option: js_measure_cloud_mode="laser"
+  ``quoted``
+    *example option*: ``js_measure_cloud_mode="laser"``
 
-    description: a double quoted string, double quotes escaped with
+    *description*: a double quoted string, double quotes escaped with
     backslash
 
-    usage: Inputs that require double quotes and allow backslash escaping
+    *usage*: Inputs that require double quotes and allow backslash escaping
     e.g. javascript/JSON inputs.
 
-  real
-     example option: n_avogadro=6.02e23
+  ``real``
+     *example option*: ``n_avogadro=6.02e23``
      
-     description: Fortran real number type, generic floating point numbers
+     *description*: Fortran real number type, generic floating point numbers
 
-     usage: Fortran real types, generic floating point numbers. Scientific
+     *usage*: Fortran real types, generic floating point numbers. Scientific
      notation must use the "e" or "E" format.
 
-     comment: Internally implemented within Rose using Python's floating
+     *comment*: Internally implemented within Rose using Python's floating
      point specification.
 
-  raw
-    description: placeholder used in derived type specifications where
+  ``raw``
+    *description*: placeholder used in derived type specifications where
     none of the above types apply
 
-    usage: only in derived types
+    *usage*: only in derived types
 
-  spaced_list
-    description: used to signify a space separated list such as "Foo" 50
-    False.
+  ``spaced_list``
+    *description*: used to signify a space separated list such as
+    ``"Foo" 50 False``.
 
-    usage: use for inputs that expect a string that contains a number of
+    *usage*: use for inputs that expect a string that contains a number of
     space separated items - e.g. in fcm_make app configs.
 
-  Note that not all inputs need to have type defined. In some cases using
-  values or pattern is better.
+  Note that not all inputs need to have ``type`` defined. In some cases
+  using ``values`` or ``pattern`` is better.
 
-  A derived type may be defined by a comma , separated list of intrinsic
-  types, e.g. integer, character, real, integer. The default is a raw string.
+  A derived type may be defined by a comma ``,`` separated list of intrinsic
+  types, e.g. ``integer, character, real, integer``. The default is a raw
+  string.
 
 length
   Define the length of an array. If not present, the setting is assumed to
-  be a scalar. A positive integer defines a fixed length array. A colon :
+  be a scalar. A positive integer defines a fixed length array. A colon ``:``
   defines a dynamic length array.
 
-  N.B. You do not need to use length if you already have type=python_list
-  for a setting.
+  N.B. You do not need to use ``length`` if you already have
+  ``type=python_list`` for a setting.
 
 element-titles
   Define a list of comma separated "titles" to appear above array entries.
@@ -283,9 +288,9 @@ element-titles
   element-titles, blank headings will be placed above them.
 
 values
-  Define a comma , separated list of permitted values of a setting (or an
-  element in the setting if it is an array). This metadata overrides the type,
-  range and pattern metadata.
+  Define a comma ``,`` separated list of permitted values of a setting (or an
+  element in the setting if it is an array). This metadata overrides the
+  ``type``, ``range`` and ``pattern`` metadata.
 
   For example, the config editor may use this list to determine the widget
   to display the setting. It may display the choices using a set of radio
@@ -295,9 +300,9 @@ values
   special setting.
 
 value-titles
-  Define a comma , separated list of titles to associate with each of the
-  elements of values which will be displayed instead of the value. This list
-  should contain the same number of elements as the values entry.
+  Define a comma ``,`` separated list of titles to associate with each of the
+  elements of ``values`` which will be displayed instead of the value. This
+  list should contain the same number of elements as the ``values`` entry.
 
   For example, given the following metadata:
 
@@ -307,13 +312,13 @@ value-titles
      values=0, 1, 2
      value-titles=low, medium, high
 
-  the config editor will display low for option value 0, medium for 1 and
-  high for 2.
+  the config editor will display ``low`` for option value ``0``, ``medium``
+  for ``1`` and ``high`` for ``2``.
 
 value-hints
-  Define a comma , separated list of suggested values for a variable as
-  value-hints, but still allows the user to provide their own override. This
-  is like an auto-complete widget.
+  Define a comma ``,`` separated list of suggested values for a variable as
+  ``value-hints``, but still allows the user to provide their own override.
+  This is like an auto-complete widget.
 
   For example, given the following metadata:
 
@@ -327,18 +332,19 @@ value-hints
   starts typing if they match a suggested value.
 
 range
-  Specify a range of values. It can either be a simple comma , separated
+  Specify a range of values. It can either be a simple comma ``,`` separated
   list of allowed values, or a logical expression in the Rose metadata
-  mini-language. This metadata is only valid if type is either integer or real.
+  mini-language. This metadata is only valid if ``type`` is either ``integer``
+  or ``real``.
 
   A simple list may contain a mixture of allowed numbers and number ranges
-  such as 1, 2, 4:8, 10:, (which means the value can be 1, 2, between 4 and 8
-  inclusive, or any values greater than or equal to 10.)
+  such as ``1, 2, 4:8, 10:`` (which means the value can be 1, 2, between 4
+  and 8 inclusive, or any values greater than or equal to 10.)
 
   A logical expression uses the Rose metadata mini-language, using the
-  variable this to denote the value of the current setting, e.g. this <-1 and
-  this >1. Inter-variable comparisons are not permitted (but see the fail-if
-  property below for a way to implement this).
+  variable ``this`` to denote the value of the current setting, e.g.
+  ``this <-1 and this >1``. Inter-variable comparisons are not permitted
+  (but see the ``fail-if`` property below for a way to implement this).
 
 pattern
   Specify a regular expression (Python's extended regular expression
@@ -351,16 +357,16 @@ pattern
      [namelist:cheese=country_of_origin]
      pattern=^"[A-Z].+"$
 
-  then we expect all valid values for country_of_origin to start with a
-  double quote (^"), begin with an uppercase letter ([A-Z]), contain some other
-  characters or spaces (.+), and end with a quote ("$).
+  then we expect all valid values for ``country_of_origin`` to start with a
+  double quote (``^"``), begin with an uppercase letter (``[A-Z]``), contain
+  some other characters or spaces (``.+``), and end with a quote (``"$``).
 
   If you have an array variable (for example,
-  TARTAN_PAINT_COLOURS='blue','red','blue') and you want to specify a pattern
-  that each element of the array must match, you can construct a regular
-  expression that repeats and includes commas. For example, if each element in
-  our TARTAN_PAINT_COLOURS array must obey the regular expression 'red'|'blue',
-  then we can write:
+  ``TARTAN_PAINT_COLOURS='blue','red','blue'``) and you want to specify a
+  pattern that each element of the array must match, you can construct a
+  regular expression that repeats and includes commas. For example, if each
+  element in our ``TARTAN_PAINT_COLOURS`` array must obey the regular
+  expression ``'red'|'blue'``, then we can write:
 
   .. code-block:: rose
 
@@ -371,20 +377,20 @@ pattern
 fail-if, warn-if
   Specify a logical expression using the Rose mini-language to validate the
   value of the current setting with respect to other settings. If the logical
-  expression evaluates to true in a fail-if metadata, the system will consider
-  the setting in error. On the other hand, in a warn-if metadata, the system
-  will only issue a warning. The logical expression uses a Python-like syntax
-  (documented fully in the appendix). It can reference the value of the current
-  setting with the this variable and the value of other settings with their
-  IDs. E.g.:
+  expression evaluates to true in a ``fail-if`` metadata, the system will
+  consider the setting in error. On the other hand, in a ``warn-if`` metadata,
+  the system will only issue a warning. The logical expression uses a
+  Python-like syntax (documented fully in the appendix). It can reference the
+  value of the current setting with the ``this`` variable and the value of
+  other settings with their IDs. E.g.:
 
   .. code-block:: rose
 
      [namelist:test=my_test_var]
      fail-if=this < namelist:test=control_lt_var;
 
-  means that an error will be flagged if the numeric value of my_test_var
-  is less than the numeric value of control_lt_var.
+  means that an error will be flagged if the numeric value of ``my_test_var``
+  is less than the numeric value of ``control_lt_var``.
 
   .. code-block:: rose
 
@@ -400,14 +406,14 @@ fail-if, warn-if
 
      fail-if=this(2) != "'0A'" and this(4) == "'0A'";
 
-  Array elements can also be checked using any and all. E.g.:
+  Array elements can also be checked using ``any`` and ``all``. E.g.:
 
   .. code-block:: rose
 
      fail-if=any(namelist:test=ctrl_array < this);
      fail-if=all(this == 0);
 
-  Similarly, the number of array elements can be checked using len. E.g.:
+  Similarly, the number of array elements can be checked using ``len``. E.g.:
 
   .. code-block:: rose
 
@@ -424,8 +430,8 @@ fail-if, warn-if
   Multiple failure conditions can be added, by using a semicolon as the
   separator - the semicolon is optional for a single statement or the last in
   a block, but is recommended. Multiple failure conditions are essentially
-  similar to chaining them together with or, but the system can process each
-  expression one by one to target the error message.
+  similar to chaining them together with ``or``, but the system can process
+  each expression one by one to target the error message.
 
   .. code-block:: rose
 
@@ -460,12 +466,13 @@ fail-if, warn-if
 
   Please note: when dividing a real-numbered setting by something, make
   sure that the expression does not actually divide an integer by an
-  integer - for example, this / 2 will evaluate as 0 if this has a value of 1,
-  but 0.5 if it has a value of 1.0. This is a result of Python's implicit
-  typing.
+  integer - for example, ``this / 2`` will evaluate as ``0`` if ``this`` has
+  a value of ``1``, but ``0.5`` if it has a value of ``1.0``. This is a
+  result of Python's implicit typing.
 
   You can get around this by making sure either the numerator or denominator 
-  is a real number - e.g. by rewriting it as this / 2.0 or 1.0 * this / 2.
+  is a real number - e.g. by rewriting it as ``this / 2.0`` or
+  ``1.0 * this / 2``.
 
 Metadata for Behaviour
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -474,7 +481,7 @@ These metadata are used to define how the setting should behave in different
 states.
 
 compulsory
-  A true value indicates that the setting should be compulsory. If this
+  A ``true`` value indicates that the setting should be compulsory. If this
   flag is not set, the setting is optional.
 
   Compulsory sections should be physically present in the configuration at
@@ -490,9 +497,9 @@ trigger
   A setting has the following states:
 
   * normal
-  * user ignored (stored in the configuration file with a ! flag, ignored
+  * user ignored (stored in the configuration file with a ``!`` flag, ignored
     at run time)
-  * logically ignored (stored in the configuration file with a !! flag,
+  * logically ignored (stored in the configuration file with a ``!!`` flag,
     ignored at runtime)
 
   If a setting is user ignored, the trigger will do nothing. Otherwise:
@@ -507,9 +514,9 @@ trigger
 
   The syntax contains id-values pairs, where the values part is optional.
   Each pair must be separated by a semi-colon. Within each pair, any values
-  must be separated from the id by a colon and a space (: ). Values must be
-  formatted in the same way as the setting "values" defined above (i.e. comma
-  separated).
+  must be separated from the id by a colon and a space (``:``). Values must
+  be formatted in the same way as the setting "values" defined above (i.e.
+  comma separated).
 
   The trigger syntax looks like:
 
@@ -524,23 +531,26 @@ trigger
 
   In this example:
 
-  * When namelist:trig_nl=trigger_variable is ignored, all the variables
+  * When ``namelist:trig_nl=trigger_variable`` is ignored, all the variables
     in the trigger expression will be ignored, irrespective of its value.
-  * When namelist:trig_nl=trigger_variable is enabled, namelist:dep_nl=A
-    and namelist:dep_nl=B will both be enabled, and the other variables
-    may be enabled according to its value:
+  * When ``namelist:trig_nl=trigger_variable`` is enabled,
+    ``namelist:dep_nl=A`` and ``namelist:dep_nl=B`` will both be enabled,
+    and the other variables may be enabled according to its value:
 
-    * When the value of the setting is not 10, 20, 30, or 40,
-      namelist:value_nl=X, env=Y and namelist:value_nl=Z will be ignored.
-    * When the value of the setting is 10, namelist:value_nl=X will be
-      enabled, but env=Y and namelist:value_nl=Z will be ignored.
-    * When the value of the setting is 20, env=Y and
-      namelist:value_nl=Z will be enabled, but namelist:value_nl=X will
-      be ignored.
-    * When the value of the setting is 30, env=Y will be enabled,
-      but namelist:value_nl=X and namelist:value_nl=Z will be ignored.
+    * When the value of the setting is not ``10``, ``20``, ``30``, or ``40``,
+      ``namelist:value_nl=X``, ``env=Y`` and ``namelist:value_nl=Z`` will be
+      ignored.
+    * When the value of the setting is ``10``, ``namelist:value_nl=X`` will be
+      enabled, but ``env=Y`` and ``namelist:value_nl=Z`` will be ignored.
+    * When the value of the setting is ``20``, ``env=Y`` and
+      ``namelist:value_nl=Z`` will be enabled, but ``namelist:value_nl=X``
+      will be ignored.
+    * When the value of the setting is ``30``, ``env=Y`` will be enabled,
+      but ``namelist:value_nl=X`` and ``namelist:value_nl=Z`` will be
+      ignored.
     * If the value of the setting contains an environment
-      variable-like string, e.g. ${TEN_MULTIPLE}, all three will be enabled.
+      variable-like string, e.g. ``${TEN_MULTIPLE}``, all three will be
+      enabled.
 
   Settings mentioned in trigger expressions will have their default
   state set to ignored unless explicitly triggered. The config editor will
@@ -548,7 +558,7 @@ trigger
   loads a configuration. Triggering thereafter will work as normal.
 
   Where multiple triggers act on a setting, the setting is triggered only
-  if all triggers are active (i.e. an AND relationship). For example, for
+  if all triggers are active (i.e. an *AND* relationship). For example, for
   the two triggers here:
 
   .. code-block:: rose
@@ -559,12 +569,12 @@ trigger
      [env=IS_COLD]
      trigger=env=IS_ICE: true;
 
-  the setting env=IS_ICE is only enabled if both env=IS_WATER and
-  env=IS_COLD are true and enabled. Otherwise, it is ignored.
+  the setting ``env=IS_ICE`` is only enabled if both ``env=IS_WATER`` and
+  ``env=IS_COLD`` are ``true`` and enabled. Otherwise, it is ignored.
 
   The trigger syntax also supports a logical expression using the Rose 
-  metadata mini-language, in the same way as the range or fail-if metadata.
-  As with range, inter-variable comparisons are disallowed.
+  metadata mini-language, in the same way as the ``range`` or ``fail-if``
+  metadata. As with ``range``, inter-variable comparisons are disallowed.
 
   .. code-block:: rose
 
@@ -572,11 +582,12 @@ trigger
      trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
              env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
 
-  In this example, the setting env=CUSTOM_SNOWFLAKE_GEOMETRY is enabled
-  if env=SNOWFLAKE_SIDES is enabled and not 6. env=SILLY_SNOWFLAKE_GEOMETRY is
-  only enabled when env=SNOWFLAKE_SIDES is enabled and less than 2. The
-  logical expression syntax can be used with non-numeric variables in the
-  same way as the fail-if metadata.
+  In this example, the setting ``env=CUSTOM_SNOWFLAKE_GEOMETRY`` is enabled
+  if ``env=SNOWFLAKE_SIDES`` is enabled and not ``6``.
+  ``env=SILLY_SNOWFLAKE_GEOMETRY`` is only enabled when
+  ``env=SNOWFLAKE_SIDES`` is enabled and less than ``2``. The logical
+  expression syntax can be used with non-numeric variables in the same way
+  as the fail-if metadata.
 
 duplicate
   Allow duplicated copies of the setting. This is used for sections where
@@ -592,17 +603,17 @@ macro
   Associate a setting with a comma-delimited set of custom macros (but not
   upgrade macros).
 
-  E.g. for a macro class called FibonacciChecker in the metadata under
-  lib/python/macros/fib.py, we may have:
+  E.g. for a macro class called ``FibonacciChecker`` in the metadata under
+  ``lib/python/macros/fib.py``, we may have:
 
   .. code-block:: rose
 
      macro=fib.FibonacciChecker
 
   This may be used in the config editor to visually associate the setting
-  with these macros. If a macro class has both a transform and a validate
-  method, you can specify which you need by appending the method to the name
-  e.g.:
+  with these macros. If a macro class has both a ``transform`` and a
+  ``validate`` method, you can specify which you need by appending the
+  method to the name e.g.:
 
   .. code-block:: rose
 
@@ -616,25 +627,25 @@ widget[gui-application]
   point real number.
 
   The widget may take space-delimited arguments which would be specified
-  after the widget name. E.g. to set up a hypothetical table with named columns
-  X, Y, VCT, and Level, we may do:
+  after the widget name. E.g. to set up a hypothetical table with named
+  columns X, Y, VCT, and Level, we may do:
 
   .. code-block:: rose
 
      widget[rose-config-edit]=table.TableWidget X Y VCT Level
 
-  You may override to a Rose built-in widget by specifying a full rose
-  class path in Python - for example, to always show radiobuttons for an option
-  with values set:
+  You may override to a Rose built-in widget by specifying a full ``rose``
+  class path in Python - for example, to always show radiobuttons for an
+  option with ``values`` set:
 
   .. code-block:: rose
 
      widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
 
   Another useful Rose built-in widget to use is the array element aligning
-  page widget, rose.config_editor.pagewidget.table.PageArrayTable. You can set
-  this for a section or namespace to make sure each nth variable value element
-  lines up horizontally. For example:
+  page widget, ``rose.config_editor.pagewidget.table.PageArrayTable``. You
+  can set this for a section or namespace to make sure each nth variable
+  value element lines up horizontally. For example:
 
   .. code-block:: rose
 
@@ -662,7 +673,7 @@ widget[gui-application]
 
 copy-mode (metadata usage with the rose-suite.info file)
   Setting copy-mode in the metadata allows for the field to be either
-  never copied or copied with any value associated to be clear.
+  ``never`` copied or copied with any value associated to be ``clear``.
 
   For example: in a rose-suite.info file
 
@@ -671,17 +682,17 @@ copy-mode (metadata usage with the rose-suite.info file)
      [ensemble members]
      copy-mode=never
 
-  Setting the ensemble members field to include copy-mode=never means
-  that the ensemble members field would never be copied.
+  Setting the ``ensemble members`` field to include ``copy-mode=never``
+  means that the ensemble members field would never be copied.
 
    .. code-block:: rose
 
       [additional info]
       copy-mode=clear
 
-  Setting the additional info field to include copy-mode=never means that
-  the additional info field would be copied, but any value associated with
-  it would be cleared.
+  Setting the ``additional info`` field to include ``copy-mode=never`` means
+  that the additional info field would be copied, but any value associated
+  with it would be cleared.
 
 Metadata for Help
 ^^^^^^^^^^^^^^^^^
@@ -718,7 +729,7 @@ help
 
      help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test to do something linear.
 
-  Web URLs beginning with http:// will also be presented as links in the
+  Web URLs beginning with ``http://`` will also be presented as links in the
   config editor.
 
 description
@@ -739,16 +750,16 @@ title
 Appendix: Metadata Location
 ---------------------------
 
-Centralised Rose metadata is referred to with either the meta or project
-top level flag in a configuration. It needs to live in a
+Centralised Rose metadata is referred to with either the ``meta`` or
+``project`` top level flag in a configuration. It needs to live in a
 system-global-readable location.
 
 Rose utilities will do a path search for metadata using the following in
 order of precedence:
 
-* The --meta-path=PATH option of relevant commands.
-* The content of the ROSE_META_PATH environment variable.
-* The meta-path setting in site/user configurations.
+* The ``--meta-path=PATH`` option of relevant commands.
+* The content of the ``ROSE_META_PATH`` environment variable.
+* The ``meta-path`` setting in site/user configurations.
 
 Each of the above settings can be a colon-separated list of paths.
 
@@ -767,14 +778,14 @@ Note that, in some cases, a number of different executables may share the
 same application configuration metadata in which case APP is given a name
 which covers all the uses.
 
-The Rose team recommend placing metadata in a rose-meta directory at the
-top of a project's source tree. Central metadata, if any, at the meta-path
-location in the site configuration, should be a collection of
-regularly-updated subdirectories from all of the relevant projects' rose-meta
-directories.
+The Rose team recommend placing metadata in a ``rose-meta`` directory at the
+top of a project's source tree. Central metadata, if any, at the
+``meta-path`` location in the site configuration, should be a collection of
+regularly-updated subdirectories from all of the relevant projects'
+``rose-meta`` directories.
 
-For example, a system CHOCOLATE may have a flat metadata structure within
-the repository:
+For example, a system ``CHOCOLATE`` may have a flat metadata structure
+within the repository:
 
    .. code-block:: bash
 
@@ -785,7 +796,7 @@ the repository:
       CHOCOLATE/rose-meta/choc-milk/
     
 
-and the system CAFFEINE may have a hybrid structure, with both flat and 
+and the system ``CAFFEINE`` may have a hybrid structure, with both flat and
 hierarchical components:
 
    .. code-block:: rose
@@ -804,7 +815,7 @@ and a site configuration with:
 
       meta-path=/path/to/rose-meta
 
-We would expect the following directories in /path/to/rose-meta:
+We would expect the following directories in ``/path/to/rose-meta``:
 
    .. code-block:: bash
 
@@ -814,8 +825,8 @@ We would expect the following directories in /path/to/rose-meta:
       /path/to/rose-meta/choc-dark/
       /path/to/rose-meta/choc-milk/
 
-with caffeine-coffee containing subdirectories cappuccino and latte, and
-caffeine-tea containing yorkshire and lapsang
+with ``caffeine-coffee`` containing subdirectories ``cappuccino`` and
+``latte``, and ``caffeine-tea`` containing ``yorkshire`` and ``lapsang``.
 
 
 Appendix: Upgrade and Versions
@@ -881,7 +892,7 @@ If the version defined does not correspond to a tagged version then a warning
 will be given.
 
 Please note that if a hierarchical structure for the metadata is being used,
-the HEAD tag must be specified explictly.
+the ``HEAD`` tag must be specified explictly.
 
 When to create named versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -923,7 +934,7 @@ commands which you want to configure using the same set of inputs (i.e. a
 single application configuration).
 
 This works by setting an alternate command in the application configuration
-and then using the `--command-key` option to `rose app-run`.
+and then using the ``--command-key`` option to ``rose app-run``.
 
 Using development versions of upgrade macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -931,7 +942,7 @@ Using development versions of upgrade macros
 Users will be able to test out development versions of the upgrade macros by
 adding a working copy of the relevant branch into their metadata search path.
 However, care must be taken when doing this. Running the upgrade macro will
-change the `meta` setting to refer to the new tag. If the upgrade macro is
+change the ``meta`` setting to refer to the new tag. If the upgrade macro is
 subsequently changed or other upgrade macros are added to the chain prior to
 this tag (because they get committed to the trunk first) then this will
 result in application configurations which have not gone through the correct
@@ -946,14 +957,15 @@ Appendix: Metadata Mini-Language
 The Rose metadata mini-language supports writing a logical expression in
 Python-like syntax, using variable ids to reference their associated values.
 
-Expressions are set as the value of metadata properties such as fail-if and
-range.
+Expressions are set as the value of metadata properties such as ``fail-if``
+and ``range``.
 
 The language is a small sub-set of Python - a limited set of operators is
 supported. No built-in object methods, functions, or modules are
-supported - neither are control blocks such as if/for, statements such as
-del or with, or defining your own functions or classes. Anything that
-requires that kind of power should be in proper Python code as a macro.
+supported - neither are control blocks such as ``if``\/``for``, statements
+such as ``del`` or ``with``, or defining your own functions or classes.
+Anything that requires that kind of power should be in proper Python code
+as a macro.
 
 Nevertheless, the language allows considerable power in terms of defining
 simple rules for variable values.
@@ -961,7 +973,7 @@ simple rules for variable values.
 Operators
 ^^^^^^^^^
 
-The following numeric operators are supported:
+The following *numeric* operators are supported:
 
    .. code-block:: rose
 
@@ -973,7 +985,7 @@ The following numeric operators are supported:
       //    # integer divide (floor) - e.g. 3 // 2 implies 1
       %     # remainder e.g. 5 % 3 implies 2
 
-The following string operators are supported:
+The following *string* operators are supported:
 
    .. code-block:: rose
 
@@ -991,7 +1003,7 @@ The following string operators are supported:
         "oobar"
       [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
 
-The following logical operators are supported:
+The following *logical* operators are supported:
 
    .. code-block:: rose
 
@@ -999,7 +1011,7 @@ The following logical operators are supported:
       or    # Logical OR
       not   # Logical NOT
 
-The following comparison operators are supported:
+The following *comparison* operators are supported:
 
    .. code-block:: rose
 
@@ -1012,8 +1024,8 @@ The following comparison operators are supported:
       !=    # Not equal to
 
 Operator precedence is intended to be the same as Python. However, with the
-current choice of language engine, the % and // operators may not obey
-this - make sure you force the correct behaviour using brackets.
+current choice of language engine, the ``%`` and ``//`` operators may not
+obey this - make sure you force the correct behaviour using brackets.
 
 Constants
 ^^^^^^^^^
@@ -1055,13 +1067,13 @@ then the expression would become:
 
 If the variable is not currently available (ignored or missing) then the
 expression cannot be evaluated. If inter-variable comparisons are not allowed
-for the expression's parent option (such as with trigger and range) then
-referencing other variable ids is not allowed.
+for the expression's parent option (such as with ``trigger`` and ``range``)
+then referencing other variable ids is not allowed.
 
 In this case the expression would be false.
 
-You may use this as a placeholder for the current variable id - for example,
-the fail-if expression:
+You may use ``this`` as a placeholder for the current variable id - for
+example, the fail-if expression:
 
    .. code-block:: rose
 
@@ -1082,16 +1094,16 @@ The syntax has some special ways of dealing with variable values that are
 arrays - i.e. comma-separated lists.
 
 You can refer to a single element of the value for a given variable id
-(or this) by suffixing a number in round brackets - e.g.:
+(or ``this``) by suffixing a number in round brackets - e.g.:
 
    .. code-block:: none
 
       namelist:foo=bar(2)
 
-references the second element in the value for bar in the section
-namelist:foo. This follows Fortran index numbering and syntax, which starts
-at 1 rather than 0 - i.e. referencing the 1st element in the array foo is
-written as foo(1).
+references the second element in the value for ``bar`` in the section
+``namelist:foo``. This follows Fortran index numbering and syntax, which
+starts at 1 rather than 0 - i.e. referencing the 1st element in the array
+``foo`` is written as ``foo(1)``.
 
 If we had a configuration:
 
@@ -1100,8 +1112,8 @@ If we had a configuration:
       [namelist:foo]
       bar='a', 'b', 'c', 'd'
 
-namelist:foo=bar(2) would get substituted in an expression with 'b' when the
-expression was evaluated. For example, an expression that contained:
+``namelist:foo=bar(2)`` would get substituted in an expression with ``'b'``
+when the expression was evaluated. For example, an expression that contained:
 
    .. code-block:: none
 
@@ -1114,7 +1126,7 @@ would be evaluated as:
       'b' == 'c'
 
 Should you wish to make use of the array length in an expression you can
-make use of the len function, which behaves in the same manner as its
+make use of the ``len`` function, which behaves in the same manner as its
 Python and Fortran equivalents to return the array length. For example:
 
    .. code-block:: none
@@ -1129,20 +1141,20 @@ would be expanded to:
 
 and evaluate as true.
 
-There are two other special array functions, any and all, which behave in
-a similar fashion to their Python and Fortran equivalents, but have a
-different syntax.
+There are two other special array functions, ``any`` and ``all``, which
+behave in a similar fashion to their Python and Fortran equivalents, but
+have a different syntax.
 
-They allow you to write a shorthand expression within an any() or all()
-bracket which implies a loop over each array element. For example:
+They allow you to write a shorthand expression within an ``any()`` or
+``all()`` bracket which implies a loop over each array element. For example:
 
    .. code-block:: none
 
       any(namelist:foo=bar == 'e')
 
-evaluates true if any elements in the value of bar in the section
-namelist:foo are 'e'. For the above configuration snippet, this would be
-expanded before evaluation to be:
+evaluates true if *any* elements in the value of ``bar`` in the section
+``namelist:foo`` are ``'e'``. For the above configuration snippet, this
+would be expanded before evaluation to be:
 
    .. code-block:: none
 
@@ -1154,8 +1166,8 @@ Similarly,
 
       all(namelist:foo=bar == 'e')
 
-evaluates true if all elements are 'e'. Again, with the above configuration,
-this would be expanded before proper evaluation:
+evaluates true if *all* elements are ``'e'``. Again, with the above
+configuration, this would be expanded before proper evaluation:
 
    .. code-block:: none
 
@@ -1165,13 +1177,13 @@ Internals
 ^^^^^^^^^
 
 Rose uses an external engine to evaluate the raw language string after
-variable ids and any any() and all() functions have been substituted and
-expanded.
+variable ids and any ``any()`` and ``all()`` functions have been substituted
+and expanded.
 
 The current choice of engine is Jinja2, which is responsible for the
 details of the supported Pythonic syntax. This may change.
 
-Do not use any Jinja2-specific syntax.
+**Do not use any Jinja2-specific syntax.**
 
 
 Appendix: Config Editor Ignored Mechanics
@@ -1182,7 +1194,7 @@ an ignored state mismatch for a setting - e.g. a setting might be enabled
 when it should be trigger-ignored.
 
 The config editor differs from the strict command line macro equivalent
-because the Switch Off Metadata mode and accidentally metadata-less
+because the *Switch Off Metadata* mode and accidentally metadata-less
 configurations need to be presented in a nice way without lots of
 not-necessarily-errors. The config editor should only report the errors
 where the state is definitely wrong or makes a material difference to the user.
@@ -1192,12 +1204,12 @@ ignored state mismatches. The actual situations are considerably more
 varied, given section-ignoring and latent variables - the table holds
 the most important varieties.
 
-The State contains the actual states. The Trigger State column contains
-the trigger-mechanism's expected states. The states can be:
+The ``State`` contains the actual states. The ``Trigger State`` column
+contains the trigger-mechanism's expected states. The states can be:
 
-IT - !!
+``IT`` - ``!!``
   trigger ignored
-IU - !
+``IU`` - ``!``
   user ignored
-E - (normal)
+``E`` - **(normal)**
   enabled

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -13,6 +13,7 @@ metadata is represented in a directory with the following:
 * rose-meta.conf, the main configuration file. See for detail.
 * opt/ directory. For detail, see Optional Configuration.
 * other files, e.g.:
+
   * lib/python/widget/my_widget.py would be the location of a custom widget.
   * lib/python/macros/my_macro_validator.py would be the location of a custom
     macro.
@@ -119,55 +120,54 @@ These configuration metadata are used for grouping and sorting the IDs of
 the configurations.
 
 ns
+  A forward slash / delimited hierarchical namespace for the container of
+  the setting, which overrides the default. The default namespace for the
+  setting is derived from the first part of the ID - by splitting up the
+  section name by colons : or forward slashes /. For example, a configuration
+  with an ID namelist:var_minimise=niter_set would have the namespace
+  namelist/var_minimise. If a namespace is defined for a section, it will
+  become the default for all the settings in that section.
 
-    A forward slash / delimited hierarchical namespace for the container of
-the setting, which overrides the default. The default namespace for the
-setting is derived from the first part of the ID - by splitting up the
-section name by colons : or forward slashes /. For example, a configuration
-with an ID namelist:var_minimise=niter_set would have the namespace
-namelist/var_minimise. If a namespace is defined for a section, it will
-become the default for all the settings in that section.
+  The namespace is used by the config editor to group settings, so that
+  they can be placed in different pages. A namespace for a section will become
+  the default for all the settings in that section.
 
-    The namespace is used by the config editor to group settings, so that
-they can be placed in different pages. A namespace for a section will become
-the default for all the settings in that section.
+  Note that you should not assign namespaces to variables in duplicate
+  sections.
 
-    Note that you should not assign namespaces to variables in duplicate
-sections.
 sort-key
+  A character string that can be used as a sort key for ordering an option
+  within its namespace.
 
-    A character string that can be used as a sort key for ordering an option
-within its namespace.
+  It can also be used to order sections and namespaces.
 
-    It can also be used to order sections and namespaces.
+  The sort-key is used by the config editor to group settings on a page.
+  Items with a sort-key will be sorted to the top of a name-space. Items
+  without a sort-key will be sorted after, in ascending order of their IDs.
 
-    The sort-key is used by the config editor to group settings on a page.
-Items with a sort-key will be sorted to the top of a name-space. Items
-without a sort-key will be sorted after, in ascending order of their IDs.
+  The sorting procedure in pseudo code is a normal ASCII-like sorting of a
+  list of setting_sort_key + "~" + setting_id strings. If there is no
+  setting_sort_key, null string will be used.
 
-    The sorting procedure in pseudo code is a normal ASCII-like sorting of a
-list of setting_sort_key + "~" + setting_id strings. If there is no
-setting_sort_key, null string will be used.
+  For example, the following metadata:
 
-    For example, the following metadata:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [env=apple]
 
-      [env=apple]
+     [env=banana]
 
-      [env=banana]
+     [env=cherry]
+     sort-key=favourites-01
 
-      [env=cherry]
-      sort-key=favourites-01
+     [env=melon]
+     sort-key=do-not-like-01
 
-      [env=melon]
-      sort-key=do-not-like-01
+     [env=prune]
+     sort-key=do-not-like-00
 
-      [env=prune]
-      sort-key=do-not-like-00
-
-    would produce a sorting order of env=prune, env=melon, env=cherry,
-env=apple, env=banana.
+  would produce a sorting order of env=prune, env=melon, env=cherry,
+  env=apple, env=banana.
 
 Metadata for Values
 ^^^^^^^^^^^^^^^^^^^
@@ -179,297 +179,293 @@ a setting contains a string that looks like an environment variable, these
 metadata will normally be ignored.
 
 type
+  The type/class of the setting. The type names are based on the intrinsic
+  Fortran types, such as integer and real. Currently supported types are:
 
-    The type/class of the setting. The type names are based on the intrinsic
-Fortran types, such as integer and real. Currently supported types are:
+  boolean
+    example option: PRODUCE_THINGS=true
 
-    boolean
+    description: either true or false
 
-        example option: PRODUCE_THINGS=true
+    usage: environment variables, javascript/JSON inputs
 
-        description: either true or false
+  character
+    example option: sea_colour='blue'
 
-        usage: environment variables, javascript/JSON inputs
-    character
+    description: Fortran character type - a single quoted string, single
+    quotes escaped in pairs
 
-        example option: sea_colour='blue'
+    usage: Fortran character types
 
-        description: Fortran character type - a single quoted string, single 
-quotes escaped in pairs
+  integer
+    example option: num_lucky=5
 
-        usage: Fortran character types
-    integer
+    description: generic integer type
 
-        example option: num_lucky=5
+    usage: any integer-type input
 
-        description: generic integer type
+  logical
+    example option: l_spock=.true.
 
-        usage: any integer-type input
-    logical
+    description: Fortran logical type - either .true. or .false.
 
-        example option: l_spock=.true.
+    usage: Fortran logical types
 
-        description: Fortran logical type - either .true. or .false.
+  python_boolean
+    example option: ENABLE_THINGS=True
 
-        usage: Fortran logical types
-    python_boolean
+    description: Python boolean type - either True or False
 
-        example option: ENABLE_THINGS=True
+    usage: Python boolean types
 
-        description: Python boolean type - either True or False
+  python_list
+    description: used to signify a Python-compatible formatted list such
+    as ["Foo", 50, False]. This encapsulates length, so do not use a separate
+    length declaration for this setting.
 
-        usage: Python boolean types
-    python_list
+    usage: use for inputs that expect a string that looks like a Python
+    list - e.g. Jinja2 list input variables.
 
-        description: used to signify a Python-compatible formatted list such
-as ["Foo", 50, False]. This encapsulates length, so do not use a separate
-length declaration for this setting.
+  quoted
+    example option: js_measure_cloud_mode="laser"
 
-        usage: use for inputs that expect a string that looks like a Python
-list - e.g. Jinja2 list input variables.
-    quoted
+    description: a double quoted string, double quotes escaped with
+    backslash
 
-        example option: js_measure_cloud_mode="laser"
+    usage: Inputs that require double quotes and allow backslash escaping
+    e.g. javascript/JSON inputs.
 
-        description: a double quoted string, double quotes escaped with
-backslash
+  real
+     example option: n_avogadro=6.02e23
+     
+     description: Fortran real number type, generic floating point numbers
 
-        usage: Inputs that require double quotes and allow backslash escaping
-e.g. javascript/JSON inputs.
-    real
+     usage: Fortran real types, generic floating point numbers. Scientific
+     notation must use the "e" or "E" format.
 
-        example option: n_avogadro=6.02e23
+     comment: Internally implemented within Rose using Python's floating
+     point specification.
 
-        description: Fortran real number type, generic floating point numbers
+  raw
+    description: placeholder used in derived type specifications where
+    none of the above types apply
 
-        usage: Fortran real types, generic floating point numbers. Scientific
-notation must use the "e" or "E" format.
+    usage: only in derived types
 
-        comment: Internally implemented within Rose using Python's floating
-point specification.
-    raw
+  spaced_list
+    description: used to signify a space separated list such as "Foo" 50
+    False.
 
-        description: placeholder used in derived type specifications where
-none of the above types apply
+    usage: use for inputs that expect a string that contains a number of
+    space separated items - e.g. in fcm_make app configs.
 
-        usage: only in derived types
-    spaced_list
+  Note that not all inputs need to have type defined. In some cases using
+  values or pattern is better.
 
-        description: used to signify a space separated list such as "Foo" 50
-False.
+  A derived type may be defined by a comma , separated list of intrinsic
+  types, e.g. integer, character, real, integer. The default is a raw string.
 
-        usage: use for inputs that expect a string that contains a number of
-space separated items - e.g. in fcm_make app configs.
-
-    Note that not all inputs need to have type defined. In some cases using
-values or pattern is better.
-
-    A derived type may be defined by a comma , separated list of intrinsic
-types, e.g. integer, character, real, integer. The default is a raw string.
 length
+  Define the length of an array. If not present, the setting is assumed to
+  be a scalar. A positive integer defines a fixed length array. A colon :
+  defines a dynamic length array.
 
-    Define the length of an array. If not present, the setting is assumed to
-be a scalar. A positive integer defines a fixed length array. A colon :
-defines a dynamic length array.
+  N.B. You do not need to use length if you already have type=python_list
+  for a setting.
 
-    N.B. You do not need to use length if you already have type=python_list
-for a setting.
 element-titles
+  Define a list of comma separated "titles" to appear above array entries.
+  If not present then no titles are displayed.
 
-    Define a list of comma separated "titles" to appear above array entries.
-If not present then no titles are displayed.
+  N.B. where the number of element-titles is greater than the length of the
+  array, it will only display titles up to the length of the array.
+  Additionally, where the associated array is longer than the number of
+  element-titles, blank headings will be placed above them.
 
-    N.B. where the number of element-titles is greater than the length of the
-array, it will only display titles up to the length of the array.
-Additionally, where the associated array is longer than the number of
-element-titles, blank headings will be placed above them.
 values
+  Define a comma , separated list of permitted values of a setting (or an
+  element in the setting if it is an array). This metadata overrides the type,
+  range and pattern metadata.
 
-    Define a comma , separated list of permitted values of a setting (or an
-element in the setting if it is an array). This metadata overrides the type,
-range and pattern metadata.
+  For example, the config editor may use this list to determine the widget
+  to display the setting. It may display the choices using a set of radio
+  buttons if the list of values is small, or a drop down combo box if the list
+  of values is large. If the list only contains one value, the config editor
+  will expect the setting to always have this value, and may display it as a
+  special setting.
 
-    For example, the config editor may use this list to determine the widget
-to display the setting. It may display the choices using a set of radio
-buttons if the list of values is small, or a drop down combo box if the list
-of values is large. If the list only contains one value, the config editor
-will expect the setting to always have this value, and may display it as a
-special setting.
 value-titles
+  Define a comma , separated list of titles to associate with each of the
+  elements of values which will be displayed instead of the value. This list
+  should contain the same number of elements as the values entry.
 
-    Define a comma , separated list of titles to associate with each of the
-elements of values which will be displayed instead of the value. This list
-should contain the same number of elements as the values entry.
+  For example, given the following metadata:
 
-    For example, given the following metadata:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [env=HEAT]
+     values=0, 1, 2
+     value-titles=low, medium, high
 
-      [env=HEAT]
-      values=0, 1, 2
-      value-titles=low, medium, high
+  the config editor will display low for option value 0, medium for 1 and
+  high for 2.
 
-    the config editor will display low for option value 0, medium for 1 and
-high for 2.
 value-hints
+  Define a comma , separated list of suggested values for a variable as
+  value-hints, but still allows the user to provide their own override. This
+  is like an auto-complete widget.
 
-    Define a comma , separated list of suggested values for a variable as
-value-hints, but still allows the user to provide their own override. This
-is like an auto-complete widget.
+  For example, given the following metadata:
 
-    For example, given the following metadata:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [env=suggested_fruit]
+     value-hints=pineapple,cherry,banana,apple,pear,mango,kiwi,grapes,peach,fig,
+                =orange,strawberry,blackberry,blackcurrent,raspberry,melon,plum
 
-      [env=suggested_fruit]
-      value-hints=pineapple,cherry,banana,apple,pear,mango,kiwi,grapes,peach,fig,
-               =orange,strawberry,blackberry,blackcurrent,raspberry,melon,plum
+  the config editor will display possible option values when the user
+  starts typing if they match a suggested value.
 
-    the config editor will display possible option values when the user
-starts typing if they match a suggested value.
 range
+  Specify a range of values. It can either be a simple comma , separated
+  list of allowed values, or a logical expression in the Rose metadata
+  mini-language. This metadata is only valid if type is either integer or real.
 
-    Specify a range of values. It can either be a simple comma , separated
-list of allowed values, or a logical expression in the Rose metadata
-mini-language. This metadata is only valid if type is either integer or real.
+  A simple list may contain a mixture of allowed numbers and number ranges
+  such as 1, 2, 4:8, 10:, (which means the value can be 1, 2, between 4 and 8
+  inclusive, or any values greater than or equal to 10.)
 
-    A simple list may contain a mixture of allowed numbers and number ranges
-such as 1, 2, 4:8, 10:, (which means the value can be 1, 2, between 4 and 8
-inclusive, or any values greater than or equal to 10.)
+  A logical expression uses the Rose metadata mini-language, using the
+  variable this to denote the value of the current setting, e.g. this <-1 and
+  this >1. Inter-variable comparisons are not permitted (but see the fail-if
+  property below for a way to implement this).
 
-    A logical expression uses the Rose metadata mini-language, using the
-variable this to denote the value of the current setting, e.g. this <-1 and
-this >1. Inter-variable comparisons are not permitted (but see the fail-if
-property below for a way to implement this).
 pattern
+  Specify a regular expression (Python's extended regular expression
+  syntax) to compare against the whole value of the setting.
 
-    Specify a regular expression (Python's extended regular expression
-syntax) to compare against the whole value of the setting.
+  For example, if we write the following metadata:
 
-    For example, if we write the following metadata:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:cheese=country_of_origin]
+     pattern=^"[A-Z].+"$
 
-      [namelist:cheese=country_of_origin]
-      pattern=^"[A-Z].+"$
+  then we expect all valid values for country_of_origin to start with a
+  double quote (^"), begin with an uppercase letter ([A-Z]), contain some other
+  characters or spaces (.+), and end with a quote ("$).
 
-    then we expect all valid values for country_of_origin to start with a
-double quote (^"), begin with an uppercase letter ([A-Z]), contain some other
-characters or spaces (.+), and end with a quote ("$).
+  If you have an array variable (for example,
+  TARTAN_PAINT_COLOURS='blue','red','blue') and you want to specify a pattern
+  that each element of the array must match, you can construct a regular
+  expression that repeats and includes commas. For example, if each element in
+  our TARTAN_PAINT_COLOURS array must obey the regular expression 'red'|'blue',
+  then we can write:
 
-    If you have an array variable (for example,
-TARTAN_PAINT_COLOURS='blue','red','blue') and you want to specify a pattern
-that each element of the array must match, you can construct a regular
-expression that repeats and includes commas. For example, if each element in
-our TARTAN_PAINT_COLOURS array must obey the regular expression 'red'|'blue',
-then we can write:
+  .. code-block:: rose
 
-   .. code-block:: rose
-
-      [env=TARTAN_PAINT_COLOURS]
-      length=:
-      pattern=^('red'|'blue')(?:,('red'|'blue'))*$
+     [env=TARTAN_PAINT_COLOURS]
+     length=:
+     pattern=^('red'|'blue')(?:,('red'|'blue'))*$
 
 fail-if, warn-if
+  Specify a logical expression using the Rose mini-language to validate the
+  value of the current setting with respect to other settings. If the logical
+  expression evaluates to true in a fail-if metadata, the system will consider
+  the setting in error. On the other hand, in a warn-if metadata, the system
+  will only issue a warning. The logical expression uses a Python-like syntax
+  (documented fully in the appendix). It can reference the value of the current
+  setting with the this variable and the value of other settings with their
+  IDs. E.g.:
 
-    Specify a logical expression using the Rose mini-language to validate the
-value of the current setting with respect to other settings. If the logical
-expression evaluates to true in a fail-if metadata, the system will consider
-the setting in error. On the other hand, in a warn-if metadata, the system
-will only issue a warning. The logical expression uses a Python-like syntax
-(documented fully in the appendix). It can reference the value of the current
-setting with the this variable and the value of other settings with their IDs.
-E.g.:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:test=my_test_var]
+     fail-if=this < namelist:test=control_lt_var;
 
-      [namelist:test=my_test_var]
-      fail-if=this < namelist:test=control_lt_var;
+  means that an error will be flagged if the numeric value of my_test_var
+  is less than the numeric value of control_lt_var.
 
-    means that an error will be flagged if the numeric value of my_test_var
-is less than the numeric value of control_lt_var.
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=this != 1 + namelist:test=ctrl_var_1 *
+     (namelist:test=ctrl_var_2 - this);
 
-      fail-if=this != 1 + namelist:test=ctrl_var_1 *
-      (namelist:test=ctrl_var_2 - this);
+  shows a more complex operation, again with numeric values.
 
-    shows a more complex operation, again with numeric values.
+  To check array elements, the ID should be expressed with a bracketed
+  index, as in the configuration:
 
-    To check array elements, the ID should be expressed with a bracketed
-index, as in the configuration:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=this(2) != "'0A'" and this(4) == "'0A'";
 
-      fail-if=this(2) != "'0A'" and this(4) == "'0A'";
+  Array elements can also be checked using any and all. E.g.:
 
-    Array elements can also be checked using any and all. E.g.:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=any(namelist:test=ctrl_array < this);
+     fail-if=all(this == 0);
 
-      fail-if=any(namelist:test=ctrl_array < this);
-      fail-if=all(this == 0);
+  Similarly, the number of array elements can be checked using len. E.g.:
 
-    Similarly, the number of array elements can be checked using len. E.g.:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=len(namelist:test=ctrl_array) < this;
+     fail-if=len(this) == 0;
 
-      fail-if=len(namelist:test=ctrl_array) < this;
-      fail-if=len(this) == 0;
+  Expressions can be chained together and brackets used:
 
-    Expressions can be chained together and brackets used:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or
+     namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
 
-      fail-if=this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or
-      namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
+  Multiple failure conditions can be added, by using a semicolon as the
+  separator - the semicolon is optional for a single statement or the last in
+  a block, but is recommended. Multiple failure conditions are essentially
+  similar to chaining them together with or, but the system can process each
+  expression one by one to target the error message.
 
-    Multiple failure conditions can be added, by using a semicolon as the
-separator - the semicolon is optional for a single statement or the last in a
-block, but is recommended. Multiple failure conditions are essentially similar
-to chaining them together with or, but the system can process each expression
-one by one to target the error message.
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=this > 0; this % 2 == 1; this * 3 > 100;
 
-      fail-if=this > 0; this % 2 == 1; this * 3 > 100;
+  You can add a message to the error or warning message to make it clearer
+  by adding a hash followed by the comment at the end of a configuration
+  metadata line:
 
-    You can add a message to the error or warning message to make it clearer
-by adding a hash followed by the comment at the end of a configuration
-metadata line:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common divisor for ctrl_array
 
-      fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common
-divisor for ctrl_array
+  When using multiple failure conditions, different messages can be added
+  if they are placed on individual lines:
 
-    When using multiple failure conditions, different messages can be added
-if they are placed on individual lines:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     fail-if=this > 0; # Needs to be less than or equal to 0
+             this % 2 == 1; # Needs to be odd
+             this * 3 > 100; # Needs to be more than 100/3.
 
-      fail-if=this > 0; # Needs to be less than or equal to 0
-              this % 2 == 1; # Needs to be odd
-              this * 3 > 100; # Needs to be more than 100/3.
+  A slightly different usage of this functionality can do things like
+  warn of deprecated content:
 
-    A slightly different usage of this functionality can do things like
-warn of deprecated content:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     warn-if=True;  # This option is deprecated
 
-      warn-if=True;  # This option is deprecated
+  This would always evaluate True and give a warning if the setting is
+  present.
 
-    This would always evaluate True and give a warning if the setting is
-present.
+  Please note: when dividing a real-numbered setting by something, make
+  sure that the expression does not actually divide an integer by an
+  integer - for example, this / 2 will evaluate as 0 if this has a value of 1,
+  but 0.5 if it has a value of 1.0. This is a result of Python's implicit
+  typing.
 
-    Please note: when dividing a real-numbered setting by something, make
-sure that the expression does not actually divide an integer by an
-integer - for example, this / 2 will evaluate as 0 if this has a value of 1,
-but 0.5 if it has a value of 1.0. This is a result of Python's implicit
-typing.
-
-    You can get around this by making sure either the numerator or denominator 
-is a real number - e.g. by rewriting it as this / 2.0 or 1.0 * this / 2.
+  You can get around this by making sure either the numerator or denominator 
+  is a real number - e.g. by rewriting it as this / 2.0 or 1.0 * this / 2.
 
 Metadata for Behaviour
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -478,217 +474,214 @@ These metadata are used to define how the setting should behave in different
 states.
 
 compulsory
+  A true value indicates that the setting should be compulsory. If this
+  flag is not set, the setting is optional.
 
-    A true value indicates that the setting should be compulsory. If this
-flag is not set, the setting is optional.
+  Compulsory sections should be physically present in the configuration at
+  all times. Compulsory options should be physically present in the
+  configuration if their parent section is physically present.
 
-    Compulsory sections should be physically present in the configuration at
-all times. Compulsory options should be physically present in the
-configuration if their parent section is physically present.
-
-    Optional settings can be removed as the user wishes. Compulsory settings
-may however be triggered ignored (see below). For example, the config editor
-may issue a warning if a compulsory setting is not defined. It may also hide
-a compulsory variable that only has a single permitted value.
+  Optional settings can be removed as the user wishes. Compulsory settings
+  may however be triggered ignored (see below). For example, the config editor
+  may issue a warning if a compulsory setting is not defined. It may also hide
+  a compulsory variable that only has a single permitted value.
 
 trigger
+  A setting has the following states:
 
-    A setting has the following states:
+  * normal
+  * user ignored (stored in the configuration file with a ! flag, ignored
+    at run time)
+  * logically ignored (stored in the configuration file with a !! flag,
+    ignored at runtime)
 
-    * normal
-    * user ignored (stored in the configuration file with a ! flag, ignored
-      at run time)
-    * logically ignored (stored in the configuration file with a !! flag,
-      ignored at runtime)
+  If a setting is user ignored, the trigger will do nothing. Otherwise:
 
-    If a setting is user ignored, the trigger will do nothing. Otherwise:
+  * If the logic for a setting in the trigger is fulfilled, it will cause
+    the setting to be enabled.
+  * If it is not, it will cause the setting to be logically ignored.
 
-    * If the logic for a setting in the trigger is fulfilled, it will cause
-      the setting to be enabled.
-    * If it is not, it will cause the setting to be logically ignored.
+  The trigger expression is a list of settings triggered by (different
+  values of) this setting. If the values are not given, the setting will be
+  triggered only if the current setting is enabled.
 
-    The trigger expression is a list of settings triggered by (different
-values of) this setting. If the values are not given, the setting will be
-triggered only if the current setting is enabled.
+  The syntax contains id-values pairs, where the values part is optional.
+  Each pair must be separated by a semi-colon. Within each pair, any values
+  must be separated from the id by a colon and a space (: ). Values must be
+  formatted in the same way as the setting "values" defined above (i.e. comma
+  separated).
 
-    The syntax contains id-values pairs, where the values part is optional.
-Each pair must be separated by a semi-colon. Within each pair, any values
-must be separated from the id by a colon and a space (: ). Values must be
-formatted in the same way as the setting "values" defined above (i.e. comma
-separated).
+  The trigger syntax looks like:
 
-    The trigger syntax looks like:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:trig_nl=trigger_variable]
+     trigger=namelist:dep_nl=A;
+             namelist:dep_nl=B;
+             namelist:value_nl=X: 10;
+             env=Y: 20, 30, 40;
+             namelist:value_nl=Z: 20;
 
-      [namelist:trig_nl=trigger_variable]
-      trigger=namelist:dep_nl=A;
-              namelist:dep_nl=B;
-              namelist:value_nl=X: 10;
-              env=Y: 20, 30, 40;
-              namelist:value_nl=Z: 20;
+  In this example:
 
-    In this example:
+  * When namelist:trig_nl=trigger_variable is ignored, all the variables
+    in the trigger expression will be ignored, irrespective of its value.
+  * When namelist:trig_nl=trigger_variable is enabled, namelist:dep_nl=A
+    and namelist:dep_nl=B will both be enabled, and the other variables
+    may be enabled according to its value:
 
-    * When namelist:trig_nl=trigger_variable is ignored, all the variables
-      in the trigger expression will be ignored, irrespective of its value.
-    * When namelist:trig_nl=trigger_variable is enabled, namelist:dep_nl=A
-      and namelist:dep_nl=B will both be enabled, and the other variables
-      may be enabled according to its value:
-      * When the value of the setting is not 10, 20, 30, or 40,
-        namelist:value_nl=X, env=Y and namelist:value_nl=Z will be ignored.
-      * When the value of the setting is 10, namelist:value_nl=X will be
-        enabled, but env=Y and namelist:value_nl=Z will be ignored.
-      * When the value of the setting is 20, env=Y and
-        namelist:value_nl=Z will be enabled, but namelist:value_nl=X will
-        be ignored.
-      * When the value of the setting is 30, env=Y will be enabled,
-        but namelist:value_nl=X and namelist:value_nl=Z will be ignored.
-      * If the value of the setting contains an environment
-        variable-like string, e.g. ${TEN_MULTIPLE}, all three will be enabled.
+    * When the value of the setting is not 10, 20, 30, or 40,
+      namelist:value_nl=X, env=Y and namelist:value_nl=Z will be ignored.
+    * When the value of the setting is 10, namelist:value_nl=X will be
+      enabled, but env=Y and namelist:value_nl=Z will be ignored.
+    * When the value of the setting is 20, env=Y and
+      namelist:value_nl=Z will be enabled, but namelist:value_nl=X will
+      be ignored.
+    * When the value of the setting is 30, env=Y will be enabled,
+      but namelist:value_nl=X and namelist:value_nl=Z will be ignored.
+    * If the value of the setting contains an environment
+      variable-like string, e.g. ${TEN_MULTIPLE}, all three will be enabled.
 
-    Settings mentioned in trigger expressions will have their default
-state set to ignored unless explicitly triggered. The config editor will
-issue warnings if variables or sections are in the incorrect state when it
-loads a configuration. Triggering thereafter will work as normal.
+  Settings mentioned in trigger expressions will have their default
+  state set to ignored unless explicitly triggered. The config editor will
+  issue warnings if variables or sections are in the incorrect state when it
+  loads a configuration. Triggering thereafter will work as normal.
 
-    Where multiple triggers act on a setting, the setting is triggered only
-if all triggers are active (i.e. an AND relationship). For example, for
-the two triggers here:
+  Where multiple triggers act on a setting, the setting is triggered only
+  if all triggers are active (i.e. an AND relationship). For example, for
+  the two triggers here:
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      [env=IS_WATER]
-      trigger=env=IS_ICE: true;
+     [env=IS_WATER]
+     trigger=env=IS_ICE: true;
 
-      [env=IS_COLD]
-      trigger=env=IS_ICE: true;
+     [env=IS_COLD]
+     trigger=env=IS_ICE: true;
 
-    the setting env=IS_ICE is only enabled if both env=IS_WATER and
-env=IS_COLD are true and enabled. Otherwise, it is ignored.
+  the setting env=IS_ICE is only enabled if both env=IS_WATER and
+  env=IS_COLD are true and enabled. Otherwise, it is ignored.
 
-    The trigger syntax also supports a logical expression using the Rose 
-metadata mini-language, in the same way as the range or fail-if metadata.
-As with range, inter-variable comparisons are disallowed.
+  The trigger syntax also supports a logical expression using the Rose 
+  metadata mini-language, in the same way as the range or fail-if metadata.
+  As with range, inter-variable comparisons are disallowed.
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      [env=SNOWFLAKE_SIDES]
-      trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
-              env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
+     [env=SNOWFLAKE_SIDES]
+     trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
+             env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
 
-    In this example, the setting env=CUSTOM_SNOWFLAKE_GEOMETRY is enabled
-if env=SNOWFLAKE_SIDES is enabled and not 6. env=SILLY_SNOWFLAKE_GEOMETRY is
-only enabled when env=SNOWFLAKE_SIDES is enabled and less than 2. The logical
-expression syntax can be used with non-numeric variables in the same way as
-the fail-if metadata.
+  In this example, the setting env=CUSTOM_SNOWFLAKE_GEOMETRY is enabled
+  if env=SNOWFLAKE_SIDES is enabled and not 6. env=SILLY_SNOWFLAKE_GEOMETRY is
+  only enabled when env=SNOWFLAKE_SIDES is enabled and less than 2. The
+  logical expression syntax can be used with non-numeric variables in the
+  same way as the fail-if metadata.
+
 duplicate
+  Allow duplicated copies of the setting. This is used for sections where
+  there may be more than one with the same metadata - for example multiple
+  namelist groups of the same name. If this setting is true for a given name,
+  the application configuration will accept multiple namelist groups of this
+  name. The config editor may then provide the option to clone or copy a
+  namelist to generate an additional namelist. Otherwise, the config editor
+  may issue warning for configuration sections that are found with multiple
+  copies or an index.
 
-    Allow duplicated copies of the setting. This is used for sections where
-there may be more than one with the same metadata - for example multiple
-namelist groups of the same name. If this setting is true for a given name,
-the application configuration will accept multiple namelist groups of this
-name. The config editor may then provide the option to clone or copy a
-namelist to generate an additional namelist. Otherwise, the config editor
-may issue warning for configuration sections that are found with multiple
-copies or an index.
 macro
+  Associate a setting with a comma-delimited set of custom macros (but not
+  upgrade macros).
 
-    Associate a setting with a comma-delimited set of custom macros (but not
-upgrade macros).
+  E.g. for a macro class called FibonacciChecker in the metadata under
+  lib/python/macros/fib.py, we may have:
 
-    E.g. for a macro class called FibonacciChecker in the metadata under
-lib/python/macros/fib.py, we may have:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     macro=fib.FibonacciChecker
 
-      macro=fib.FibonacciChecker
+  This may be used in the config editor to visually associate the setting
+  with these macros. If a macro class has both a transform and a validate
+  method, you can specify which you need by appending the method to the name
+  e.g.:
 
-    This may be used in the config editor to visually associate the setting
-with these macros. If a macro class has both a transform and a validate
-method, you can specify which you need by appending the method to the name
-e.g.:
+  .. code-block:: rose
 
-   .. code-block:: rose
-
-      macro=fib.Fibonacci.validate
+     macro=fib.Fibonacci.validate
 
 widget[gui-application]
+  Indicate that the gui-application (e.g. config-edit) should use a
+  special widget to display this setting.
 
-    Indicate that the gui-application (e.g. config-edit) should use a
-special widget to display this setting.
+  E.g. If we want to use a slider instead of an entry box for a floating
+  point real number.
 
-    E.g. If we want to use a slider instead of an entry box for a floating
-point real number.
+  The widget may take space-delimited arguments which would be specified
+  after the widget name. E.g. to set up a hypothetical table with named columns
+  X, Y, VCT, and Level, we may do:
 
-    The widget may take space-delimited arguments which would be specified
-after the widget name. E.g. to set up a hypothetical table with named columns
-X, Y, VCT, and Level, we may do:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit]=table.TableWidget X Y VCT Level
 
-      widget[rose-config-edit]=table.TableWidget X Y VCT Level
+  You may override to a Rose built-in widget by specifying a full rose
+  class path in Python - for example, to always show radiobuttons for an option
+  with values set:
 
-    You may override to a Rose built-in widget by specifying a full rose
-class path in Python - for example, to always show radiobuttons for an option
-with values set:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
 
-      widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
+  Another useful Rose built-in widget to use is the array element aligning
+  page widget, rose.config_editor.pagewidget.table.PageArrayTable. You can set
+  this for a section or namespace to make sure each nth variable value element
+  lines up horizontally. For example:
 
-    Another useful Rose built-in widget to use is the array element aligning
-page widget, rose.config_editor.pagewidget.table.PageArrayTable. You can set
-this for a section or namespace to make sure each nth variable value element
-lines up horizontally. For example:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:meal_choices]
+     customers='Athos','Porthos','Aramis','d''Artagnan'
+     entrees='soup','pate','soup','asparagus'
+     main='beef','spaghetti','coq au vin','lamb'
+     petits_fours=.false.,.true.,.false.,.true.
 
-      [namelist:meal_choices]
-      customers='Athos','Porthos','Aramis','d''Artagnan'
-      entrees='soup','pate','soup','asparagus'
-      main='beef','spaghetti','coq au vin','lamb'
-      petits_fours=.false.,.true.,.false.,.true.
+  could use the following metadata:
 
-    could use the following metadata:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:meal_choices]
+     widget[rose-config-edit]=rose.config_editor.pagewidget.table.PageArrayTable
 
-      [namelist:meal_choices]
-      widget[rose-config-edit]=rose.config_editor.pagewidget.table.PageArrayTable
+  to align the elements on the page like this:
 
-    to align the elements on the page like this:
+  .. code-block:: none
 
-   .. code-block:: none
-
-      customers        Athos      Porthos      Aramis      d'Artagnan
-      entrees          soup        pate         soup       asparagus
-      main             beef      spaghetti   coq au vin       lamb
-      petits_fours    .false.     .true.       .false.       .true.
+     customers        Athos      Porthos      Aramis      d'Artagnan
+     entrees          soup        pate         soup       asparagus
+     main             beef      spaghetti   coq au vin       lamb
+     petits_fours    .false.     .true.       .false.       .true.
 
 copy-mode (metadata usage with the rose-suite.info file)
+  Setting copy-mode in the metadata allows for the field to be either
+  never copied or copied with any value associated to be clear.
 
-    Setting copy-mode in the metadata allows for the field to be either
-never copied or copied with any value associated to be clear.
+  For example: in a rose-suite.info file
 
-    For example: in a rose-suite.info file
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [ensemble members]
+     copy-mode=never
 
-      [ensemble members]
-      copy-mode=never
-
-    Setting the ensemble members field to include copy-mode=never means
-that the ensemble members field would never be copied.
+  Setting the ensemble members field to include copy-mode=never means
+  that the ensemble members field would never be copied.
 
    .. code-block:: rose
 
       [additional info]
       copy-mode=clear
 
-    Setting the additional info field to include copy-mode=never means that
-the additional info field would be copied, but any value associated with it
-would be cleared.
+  Setting the additional info field to include copy-mode=never means that
+  the additional info field would be copied, but any value associated with
+  it would be cleared.
 
 Metadata for Help
 ^^^^^^^^^^^^^^^^^
@@ -696,54 +689,51 @@ Metadata for Help
 These metadata provide help for a configuration.
 
 url
+  A web URL containing help for the setting. For example:
 
-    A web URL containing help for the setting. For example:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     url=http://www.something.com/FOO/view/dev/doc/FOO.html
 
-      url=http://www.something.com/FOO/view/dev/doc/FOO.html
+  For example, the config editor will trigger a web browser to display this
+  when a variable name is clicked. A partial URL can be used for variables if
+  the variable's section or namespace has a relevant parent url property to
+  use as a prefix. For example:
 
-    For example, the config editor will trigger a web browser to display this
-when a variable name is clicked. A partial URL can be used for variables if
-the variable's section or namespace has a relevant parent url property to use
-as a prefix. For example:
+  .. code-block:: rose
 
-   .. code-block:: rose
+     [namelist:foo]
+     url=https://www.google.com/search
 
-      [namelist:foo]
-      url=https://www.google.com/search
-
-      [namelist:foo=bar]
-      url=?q=nearest+bar
+     [namelist:foo=bar]
+     url=?q=nearest+bar
 
 help
+  (Long) help for the setting. For example, the config editor will use
+  this in a popup dialog for a variable. Embedding variable ids in the help
+  string will allow links to the variables to be created within the popup
+  dialog box, e.g.
 
-    (Long) help for the setting. For example, the config editor will use
-this in a popup dialog for a variable. Embedding variable ids in the help
-string will allow links to the variables to be created within the popup
-dialog box, e.g.
+  .. code-block:: rose
 
-   .. code-block:: rose
+     help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test to do something linear.
 
-      help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test
-to do something linear.
+  Web URLs beginning with http:// will also be presented as links in the
+  config editor.
 
-    Web URLs beginning with http:// will also be presented as links in the
-config editor.
 description
+  (Medium) description for the setting. For example, the configuration
+  editor will use this as part of the hover over text.
 
-    (Medium) description for the setting. For example, the configuration
-editor will use this as part of the hover over text.
+  The config editor will also use descriptions set for sections or
+  namespaces as page header text (appears at the top of a panel or page),
+  with clickable id and URL links as in help. Descriptions set for variables
+  may be automatically shown underneath the variable name in the config editor,
+  depending on view options.
 
-    The config editor will also use descriptions set for sections or
-namespaces as page header text (appears at the top of a panel or page),
-with clickable id and URL links as in help. Descriptions set for variables
-may be automatically shown underneath the variable name in the config editor,
-depending on view options.
 title
-
-    (Short) title for the setting. For example, the config editor can use
-this specification as the label of a setting, instead of the variable name.
+  (Short) title for the setting. For example, the config editor can use
+  this specification as the label of a setting, instead of the variable name.
 
 
 Appendix: Metadata Location
@@ -834,13 +824,14 @@ Appendix: Upgrade and Versions
 Terminology:
 
 The HEAD (i.e. development) version
-    The configuration metadata most relevant to the latest revision of the
-source tree.
+  The configuration metadata most relevant to the latest revision of the
+  source tree.
+
 A named version
-    The configuration metadata most relevant to a release, or a particular
-revision, of the software. This will normally be a copy of the HEAD version
-at a given revision, although it may be updated with some backward compatible
-fixes.
+  The configuration metadata most relevant to a release, or a particular
+  revision, of the software. This will normally be a copy of the HEAD version
+  at a given revision, although it may be updated with some backward
+  compatible fixes.
 
 Each change in the HEAD version that requires an upgrade procedure should
 introduce an upgrade macro. Each upgrade macro will provide the following
@@ -1205,8 +1196,8 @@ The State contains the actual states. The Trigger State column contains
 the trigger-mechanism's expected states. The states can be:
 
 IT - !!
-    trigger ignored
+  trigger ignored
 IU - !
-    user ignored
+  user ignored
 E - (normal)
-    enabled
+  enabled

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -1213,3 +1213,5 @@ contains the trigger-mechanism's expected states. The states can be:
   user ignored
 ``E`` - **(normal)**
   enabled
+
+  .. TODO - large table to go here

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -125,7 +125,7 @@ Metadata Options
 ^^^^^^^^^^^^^^^^
 
 The metadata options for a configuration fall into 4 categories: sorting,
-values, behaviour and help. They are be described separated below.
+values, behaviour and help. They are described separately below.
 
 Metadata for Sorting
 ^^^^^^^^^^^^^^^^^^^^

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -4,8 +4,8 @@
 .. _floating point: https://docs.python.org/3/library/stdtypes.html#typesnumeric
 .. _cast: https://docs.python.org/2/library/ast.html#ast.literal_eval
 
-.. _conf-meta:
 
+.. _conf-meta:
 
 Configuration Metadata
 ======================
@@ -124,7 +124,7 @@ Metadata Options
 ^^^^^^^^^^^^^^^^
 
 The metadata options for a configuration fall into 4 categories: sorting,
-values, behaviour and help. They are be described separated below:
+values, behaviour and help. They are be described separated below.
 
 Metadata for Sorting
 ^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ type
     ``"Foo" 50 False``.
 
     *usage*: use for inputs that expect a string that contains a number of
-    space separated items - e.g. in fcm_make app configs.
+    space separated items - e.g. in ``fcm_make`` app configs.
 
   Note that not all inputs need to have ``type`` defined. In some cases
   using ``values`` or ``pattern`` is better.
@@ -455,7 +455,7 @@ fail-if, warn-if
 
   .. code-block:: rose
 
-     fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common divisor for ctrl_array
+     fail-if=any(namelist:test=ctrl_array % this == 0); # Need common divisor for ctrl_array
 
   When using multiple failure conditions, different messages can be added
   if they are placed on individual lines:
@@ -473,7 +473,7 @@ fail-if, warn-if
 
      warn-if=True;  # This option is deprecated
 
-  This would always evaluate True and give a warning if the setting is
+  This would always evaluate ``True`` and give a warning if the setting is
   present.
 
   Please note: when dividing a real-numbered setting by something, make
@@ -526,9 +526,12 @@ trigger
 
   The syntax contains id-values pairs, where the values part is optional.
   Each pair must be separated by a semi-colon. Within each pair, any values
-  must be separated from the id by a colon and a space (``:``). Values must
-  be formatted in the same way as the setting "values" defined above (i.e.
-  comma separated).
+  must be separated from the id by a colon (``:``) and a space. Values
+  must be formatted in the same way as the setting "values" defined above
+  (i.e. comma separated).
+
+  .. NOTEFORWRITERS - it is not possible to put a space at end of double
+     backquotes so can't put ': ' in inline monospace font above :(.
 
   The trigger syntax looks like:
 
@@ -658,7 +661,7 @@ widget[gui-application]
   Another useful Rose built-in widget to use is the array element
   aligning :ref:`page widget <conf-ed-cust-pages>`,
   ``rose.config_editor.pagewidget.table.PageArrayTable``. You can set this
-  for a section or namespace to make sure each *n* th variable value element
+  for a section or namespace to make sure each *n*-th variable value element
   lines up horizontally. For example:
 
   .. code-block:: rose
@@ -685,11 +688,11 @@ widget[gui-application]
      main             beef      spaghetti   coq au vin       lamb
      petits_fours    .false.     .true.       .false.       .true.
 
-copy-mode (metadata usage with the rose-suite.info file)
+copy-mode (metadata usage with the ``rose-suite.info`` file)
   Setting copy-mode in the metadata allows for the field to be either
   ``never`` copied or copied with any value associated to be ``clear``.
 
-  For example: in a rose-suite.info file
+  For example: in a ``rose-suite.info`` file
 
   .. code-block:: rose
 
@@ -732,6 +735,9 @@ url
 
      [namelist:foo=bar]
      url=?q=nearest+bar
+
+.. TODO - mend rose syntax highlighting which is not showing the 2nd section
+   above correctly (section ':' then '=' regex inclusion required?).
 
 help
   (Long) help for the setting. For example, the config editor will use
@@ -1116,7 +1122,7 @@ arrays - i.e. comma-separated lists.
 You can refer to a single element of the value for a given variable id
 (or ``this``) by suffixing a number in round brackets - e.g.:
 
-   .. code-block:: none
+   .. code-block:: rose
 
       namelist:foo=bar(2)
 
@@ -1135,7 +1141,7 @@ If we had a configuration:
 ``namelist:foo=bar(2)`` would get substituted in an expression with ``'b'``
 when the expression was evaluated. For example, an expression that contained:
 
-   .. code-block:: none
+   .. code-block:: rose
 
       namelist:foo=bar(2) == 'c'
 
@@ -1227,6 +1233,10 @@ the most important varieties.
 The ``State`` contains the actual states. The ``Trigger State`` column
 contains the trigger-mechanism's expected states. The states can be:
 
+.. TODO - convert IT, IU, etc. markers in list and table below into symbols
+   as in old docs - can't see a way of doing this from basic rst text docs.
+   Or at least put them in a different colour etc to make them stand out.
+
 ``IT`` - ``!!``
   trigger ignored
 ``IU`` - ``!``
@@ -1261,3 +1271,5 @@ State   Trigger State      Compulsory  Display Error?  User Options  Notes
 
 .. [1] Overlooking mainly in order to de-clutter the ``No Metadata`` view.
 .. [2] Same basic state - macro will ask to fix this.
+
+.. TODO - include long table items removing need for footnotes, if possible?

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -1234,4 +1234,30 @@ contains the trigger-mechanism's expected states. The states can be:
 ``E`` - **(normal)**
   enabled
 
-  .. TODO - large table to go here
+A subset of possible ignored/enabled states, errors and fixes:
+
+======  ===============    ==========  ==============  ============  ========
+State   Trigger State      Compulsory  Display Error?  User Options  Notes
+======  ===============    ==========  ==============  ============  ========
+``IT``  ``IT``             compulsory  no              None          
+``IT``  ``IT``             optional    no              None
+``IT``  ``E``              compulsory  error           ``E``
+``IT``  ``E``              optional    error           ``E``
+``IT``  ``not trigger``    compulsory  error           ``E``
+``IT``  ``not trigger``    optional    overlook        ``E``         See [1]_
+``IU``  ``IT``             compulsory  overlook        None          See [2]_
+``IU``  ``IT``             optional    no              None
+``IU``  ``E``              compulsory  error           ``E``
+``IU``  ``E``              optional    no              ``E``
+``IU``  ``not trigger``    compulsory  error           ``E``
+``IU``  ``not trigger``    optional    no              ``E``
+``E``   ``IT``             compulsory  error           ``IT``
+``E``   ``IT``             optional    error           ``IT``
+``E``   ``E``              compulsory  no              None
+``E``   ``E``              optional    no              ``IU``
+``E``   ``not trigger``    compulsory  no              None
+``E``   ``not trigger``    optional    no              ``IU``
+======  ===============    ==========  ==============  ============  ========
+
+.. [1] Overlooking mainly in order to de-clutter the ``No Metadata`` view.
+.. [2] Same basic state - macro will ask to fix this.

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -85,38 +85,38 @@ and inherit their configuration and files if found.
 For example, you might have a ``rose-meta`` directory that contains the
 following files and directories:
 
-   .. code-block:: none
+.. code-block:: none
 
-      cheese_sandwich/
-          vn1.5/
-              rose-meta.conf
-          vn2.0/
-              rose-meta.conf
-      cheese/
-          vn1.0/
-              rose-meta.conf
+   cheese_sandwich/
+       vn1.5/
+           rose-meta.conf
+       vn2.0/
+           rose-meta.conf
+   cheese/
+       vn1.0/
+           rose-meta.conf
 
 and write an app referencing this ``rose-meta`` directory that looks like
 this:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-     meta=cheese_sandwich/vn2.0
+   meta=cheese_sandwich/vn2.0
 
-     [env]
-     CHEESE=camembert
-     SANDWICH_BREAD=brown
+   [env]
+   CHEESE=camembert
+   SANDWICH_BREAD=brown
 
 This will reference the metadata at ``rose-meta/cheese_sandwich/vn2.0``.
 
 Now, we can write the ``rose-meta.conf`` file using an import:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      import=cheese/vn1.0
+   import=cheese/vn1.0
 
-      [env=SANDWICH_BREAD]
-      values=white,brown,seeded
+   [env=SANDWICH_BREAD]
+   values=white,brown,seeded
 
 which will inherit metadata from metadata from
 ``rose-meta/cheese/vn1.0/rose-meta.conf``.
@@ -714,10 +714,10 @@ copy-mode (metadata usage with the ``rose-suite.info`` file)
   Setting the ``ensemble members`` field to include ``copy-mode=never``
   means that the ensemble members field would never be copied.
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      [additional info]
-      copy-mode=clear
+     [additional info]
+     copy-mode=clear
 
   Setting the ``additional info`` field to include ``copy-mode=never`` means
   that the additional info field would be copied, but any value associated
@@ -801,11 +801,11 @@ Each of the above settings can be a colon-separated list of paths.
 Underneath each directory in the search path should be a hierarchy like the
 following:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      ${APP}/HEAD/
-      ${APP}/${VERSION}/
-      ${APP}/versions.py # i.e. the upgrade macros
+   ${APP}/HEAD/
+   ${APP}/${VERSION}/
+   ${APP}/versions.py # i.e. the upgrade macros
 
 .. note::
    A Rose suite info is likely to have no versions.
@@ -906,21 +906,21 @@ application configuration.
 Application configurations can reference the configuration metadata as
 follows:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      #!cfg
-      # Refer to the HEAD version
-      # (typically you wouldn't do this since no upgrade process is possible)
-      # For flat metadata
-      meta=my-command
-      # For hierarchical metadata
-      meta=/path/to/metadata/my-command/HEAD
+   #!cfg
+   # Refer to the HEAD version
+   # (typically you wouldn't do this since no upgrade process is possible)
+   # For flat metadata
+   meta=my-command
+   # For hierarchical metadata
+   meta=/path/to/metadata/my-command/HEAD
 
-      # Refer to a named or tagged version in the flat metadata
-      meta=my-command/8.3
-      meta=my-command/t123
-      # Refer to a named or tagged version in the hierarchical metadata
-      meta=/path/to/metadata/my-command/8.3
+   # Refer to a named or tagged version in the flat metadata
+   meta=my-command/8.3
+   meta=my-command/t123
+   # Refer to a named or tagged version in the hierarchical metadata
+   meta=/path/to/metadata/my-command/8.3
 
 If a version is defined then the Rose utilities will first look for the
 corresponding named version. If this cannot be found then the HEAD version
@@ -1021,54 +1021,52 @@ Operators
 
 The following *numeric* operators are supported:
 
-   .. code-block:: python
+.. code-block:: python
 
-      +     # add
-      -     # subtract
-      *     # multiply
-      **    # power or exponent - e.g. 2 ** 3 implies 8
-      /     # divide
-      //    # integer divide (floor) - e.g. 3 // 2 implies 1
-      %     # remainder e.g. 5 % 3 implies 2
+   +     # add
+   -     # subtract
+   *     # multiply
+   **    # power or exponent - e.g. 2 ** 3 implies 8
+   /     # divide
+   //    # integer divide (floor) - e.g. 3 // 2 implies 1
+   %     # remainder e.g. 5 % 3 implies 2
 
 The following *string* operators are supported:
 
-   .. code-block:: python
+.. code-block:: python
 
-      +      # concatenate - e.g. "foo" + "bar" implies "foobar"
-      *      # self-concatenate some number of times - e.g. "foo" * 2 implies "foofoo"
-      %      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
-      in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
-      not in # opposite sense of in
+   +      # concatenate - e.g. "foo" + "bar" implies "foobar"
+   *      # self-concatenate some number of times - e.g. "foo" * 2 implies "foofoo"
+   %      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
+   in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
+   not in # opposite sense of in
 
-      # Where m, n are integers or expressions that evaluate to integers
-      # (negative numbers count from the end of the string):
-      [n]   # get nth character from string - e.g. "foo"[1] implies "o"
-      [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies
-            # "ooba"
-      [m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies
-            # "oobar"
-      [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
+   # Where m, n are integers or expressions that evaluate to integers
+   # (negative numbers count from the end of the string):
+   [n]   # get nth character from string - e.g. "foo"[1] implies "o"
+   [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
+   [m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies "oobar"
+   [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
 
 The following *logical* operators are supported:
 
-   .. code-block:: python
+.. code-block:: python
 
-      and   # Logical AND
-      or    # Logical OR
-      not   # Logical NOT
+   and   # Logical AND
+   or    # Logical OR
+   not   # Logical NOT
 
 The following *comparison* operators are supported:
 
-   .. code-block:: python
+.. code-block:: python
 
-      is    # Is the same object as (usually used for 'is none')
-      <     # Less than
-      >     # Greater than
-      ==    # Equal to
-      >=    # Greater than or equal to
-      <=    # Less than or equal to
-      !=    # Not equal to
+   is    # Is the same object as (usually used for 'is none')
+   <     # Less than
+   >     # Greater than
+   ==    # Equal to
+   >=    # Greater than or equal to
+   <=    # Less than or equal to
+   !=    # Not equal to
 
 Operator precedence is intended to be the same as Python. However, with the
 current choice of language engine, the ``%`` and ``//`` operators may not
@@ -1079,11 +1077,11 @@ Constants
 
 The following are special constants:
 
-   .. code-block:: python
+.. code-block:: python
 
-      None  # Python None
-      False # Python False
-      True  # Python True
+   None  # Python None
+   False # Python False
+   True  # Python True
 
 Using Variable Ids
 ^^^^^^^^^^^^^^^^^^
@@ -1094,23 +1092,23 @@ into the expression.
 
 For example, if we have a configuration that looks like this:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [namelist:zoo]
-      num_elephants=2
-      elephant_mood='peaceful'
+   [namelist:zoo]
+   num_elephants=2
+   elephant_mood='peaceful'
 
 and an expression in the configuration metadata:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      namelist:zoo=elephant_mood != 'annoyed' and num_elephants >= 2
+   namelist:zoo=elephant_mood != 'annoyed' and num_elephants >= 2
 
 then the expression would become:
 
-   .. code-block:: none
+.. code-block:: none
 
-      'peaceful' != 'annoyed' and 2 >= 2
+   'peaceful' != 'annoyed' and 2 >= 2
 
 If the variable is not currently available (ignored or missing) then the
 expression cannot be evaluated. If inter-variable comparisons are not allowed
@@ -1122,17 +1120,17 @@ In this case the expression would be false.
 You may use ``this`` as a placeholder for the current variable id - for
 example, the fail-if expression:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [namelist:foo=bar]
-      fail-if=namelist:foo=bar > 100 and namelist:foo=bar % 2 == 1
+   [namelist:foo=bar]
+   fail-if=namelist:foo=bar > 100 and namelist:foo=bar % 2 == 1
 
 is the same as:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [namelist:foo=bar]
-      fail-if=this > 100 and this % 2 == 1
+   [namelist:foo=bar]
+   fail-if=this > 100 and this % 2 == 1
 
 Arrays
 ^^^^^^
@@ -1143,9 +1141,9 @@ arrays - i.e. comma-separated lists.
 You can refer to a single element of the value for a given variable id
 (or ``this``) by suffixing a number in round brackets - e.g.:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      namelist:foo=bar(2)
+   namelist:foo=bar(2)
 
 references the second element in the value for ``bar`` in the section
 ``namelist:foo``. This follows Fortran index numbering and syntax, which
@@ -1154,37 +1152,37 @@ starts at 1 rather than 0 - i.e. referencing the 1st element in the array
 
 If we had a configuration:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [namelist:foo]
-      bar='a', 'b', 'c', 'd'
+   [namelist:foo]
+   bar='a', 'b', 'c', 'd'
 
 ``namelist:foo=bar(2)`` would get substituted in an expression with ``'b'``
 when the expression was evaluated. For example, an expression that contained:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      namelist:foo=bar(2) == 'c'
+   namelist:foo=bar(2) == 'c'
 
 would be evaluated as:
 
-   .. code-block:: none
+.. code-block:: none
 
-      'b' == 'c'
+   'b' == 'c'
 
 Should you wish to make use of the array length in an expression you can
 make use of the ``len`` function, which behaves in the same manner as its
 Python and Fortran equivalents to return the array length. For example:
 
-   .. code-block:: none
+.. code-block:: none
 
-      len(namelist:foo=bar) > 3
+   len(namelist:foo=bar) > 3
 
 would be expanded to:
 
-   .. code-block:: none
+.. code-block:: none
 
-      4 > 3
+   4 > 3
 
 and evaluate as true.
 
@@ -1195,30 +1193,30 @@ have a different syntax.
 They allow you to write a shorthand expression within an ``any()`` or
 ``all()`` bracket which implies a loop over each array element. For example:
 
-   .. code-block:: none
+.. code-block:: none
 
-      any(namelist:foo=bar == 'e')
+   any(namelist:foo=bar == 'e')
 
 evaluates true if *any* elements in the value of ``bar`` in the section
 ``namelist:foo`` are ``'e'``. For the above configuration snippet, this
 would be expanded before evaluation to be:
 
-   .. code-block:: none
+.. code-block:: none
 
-      'a' == 'e' or 'b' == 'e' or 'c' == 'e' or 'd' == 'e'
+   'a' == 'e' or 'b' == 'e' or 'c' == 'e' or 'd' == 'e'
 
 Similarly,
 
-   .. code-block:: none
+.. code-block:: none
 
-      all(namelist:foo=bar == 'e')
+   all(namelist:foo=bar == 'e')
 
 evaluates true if *all* elements are ``'e'``. Again, with the above
 configuration, this would be expanded before proper evaluation:
 
-   .. code-block:: none
+.. code-block:: none
 
-      'a' == 'e' and 'b' == 'e' and 'c' == 'e' and 'd' == 'e'
+   'a' == 'e' and 'b' == 'e' and 'c' == 'e' and 'd' == 'e'
 
 Internals
 ^^^^^^^^^

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -1,0 +1,1095 @@
+Configuration Metadata
+======================
+
+
+Format and Location
+-------------------
+
+See Configuration Format.
+
+A configuration metadata is itself a configuration. Each configuration
+metadata is represented in a directory with the following:
+
+* rose-meta.conf, the main configuration file. See for detail.
+* opt/ directory. For detail, see Optional Configuration.
+* other files, e.g.:
+  * lib/python/widget/my_widget.py would be the location of a custom widget.
+  * lib/python/macros/my_macro_validator.py would be the location of a custom
+    macro.
+  * etc/ would contain any resources for the logics in lib/python/, such
+    as an icon for the custom widget.
+
+Rose utilities will do a path search for metadata using the following in order
+of precedence:
+
+* Configuration metadata embedded in the meta/ directory of a suite or an
+  application.
+* The --meta-path=PATH option of relevant commands.
+* The value of the ROSE_META_PATH environment variable.
+* The meta-path setting in site/user configurations.
+
+See Metadata Location for more details.
+
+The configuration metadata that controls default behaviour will be located in
+$ROSE_HOME/etc/rose-meta/.
+
+
+Configuration Metadata File
+---------------------------
+
+The rose-meta.conf contains a serialised data structure that is an unordered
+map (sections=) of unordered maps (keys=values).
+
+The section name in a configuration metadata file should be a unique ID to the
+relevant configuration setting. The syntax of the ID is
+SECTION-NAME=OPTION-NAME or just SECTION-NAME. For example, env=MY_ENV_NAME is
+the ID of an environment variable called MY_ENV_NAME in an application
+configuration file; namelist:something_nl=variable_name1 is the ID of a
+namelist variable called variable_name1 in a namelist group called
+something_nl in an application configuration file. If the configuration
+metadata applies to a section in a configuration file, the ID is just the
+section name.
+
+Where multiple instances of a section are used in a configuration file,
+ending in brackets with numbers, the metadata id should just be based on the
+original section name (for example namelist:extract_control(2) should be
+found in the metadata under namelist:extract_control).
+
+Finally, the configuration metadata may group settings in namespaces, which
+may in turn have common configuration metadata settings. The ID for a
+namespace set in the metadata is ns=NAME, e.g.
+ns=env/MyFavouriteEnvironmentVars.
+
+Metadata Inheritance (Import)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A root level import=MY_COMMAND1/VERSION1 MY_COMMAND2/VERSION2 ... setting in
+the rose-meta.conf file will tell Rose metadata utilities to locate the meta
+keys MY_COMMAND1/VERSION1, MY_COMMAND2/VERSION2 (and so on) and inherit their
+configuration and files if found.
+
+For example, you might have a rose-meta directory that contains the following
+files and directories:
+
+cheese_sandwich/
+    vn1.5/
+        rose-meta.conf
+    vn2.0/
+        rose-meta.conf
+cheese/
+    vn1.0/
+        rose-meta.conf
+
+and write an app referencing this rose-meta directory that looks like this:
+
+meta=cheese_sandwich/vn2.0
+
+[env]
+CHEESE=camembert
+SANDWICH_BREAD=brown
+
+This will reference the metadata at rose-meta/cheese_sandwich/vn2.0.
+
+Now, we can write the rose-meta.conf file using an import:
+
+import=cheese/vn1.0
+
+[env=SANDWICH_BREAD]
+values=white,brown,seeded
+
+which will inherit metadata from metadata from
+rose-meta/cheese/vn1.0/rose-meta.conf.
+
+Metadata Options
+^^^^^^^^^^^^^^^^
+
+The metadata options for a configuration fall into 4 categories: sorting,
+values, behaviour and help. They are be described separated below:
+
+Metadata for Sorting
+^^^^^^^^^^^^^^^^^^^^
+
+These configuration metadata are used for grouping and sorting the IDs of
+the configurations.
+
+ns
+
+    A forward slash / delimited hierarchical namespace for the container of
+the setting, which overrides the default. The default namespace for the
+setting is derived from the first part of the ID - by splitting up the
+section name by colons : or forward slashes /. For example, a configuration
+with an ID namelist:var_minimise=niter_set would have the namespace
+namelist/var_minimise. If a namespace is defined for a section, it will
+become the default for all the settings in that section.
+
+    The namespace is used by the config editor to group settings, so that
+they can be placed in different pages. A namespace for a section will become
+the default for all the settings in that section.
+
+    Note that you should not assign namespaces to variables in duplicate
+sections.
+sort-key
+
+    A character string that can be used as a sort key for ordering an option
+within its namespace.
+
+    It can also be used to order sections and namespaces.
+
+    The sort-key is used by the config editor to group settings on a page.
+Items with a sort-key will be sorted to the top of a name-space. Items
+without a sort-key will be sorted after, in ascending order of their IDs.
+
+    The sorting procedure in pseudo code is a normal ASCII-like sorting of a
+list of setting_sort_key + "~" + setting_id strings. If there is no
+setting_sort_key, null string will be used.
+
+    For example, the following metadata:
+
+    [env=apple]
+
+    [env=banana]
+
+    [env=cherry]
+    sort-key=favourites-01
+
+    [env=melon]
+    sort-key=do-not-like-01
+
+    [env=prune]
+    sort-key=do-not-like-00
+
+    would produce a sorting order of env=prune, env=melon, env=cherry,
+env=apple, env=banana.
+
+Metadata for Values
+^^^^^^^^^^^^^^^^^^^
+
+These configuration metadata are used to define the valid values of a setting. 
+A Rose utility such as the config editor can use these metadata to display the
+correct widget for a setting and to check its input. However, if the value of
+a setting contains a string that looks like an environment variable, these
+metadata will normally be ignored.
+
+type
+
+    The type/class of the setting. The type names are based on the intrinsic
+Fortran types, such as integer and real. Currently supported types are:
+
+    boolean
+
+        example option: PRODUCE_THINGS=true
+
+        description: either true or false
+
+        usage: environment variables, javascript/JSON inputs
+    character
+
+        example option: sea_colour='blue'
+
+        description: Fortran character type - a single quoted string, single 
+quotes escaped in pairs
+
+        usage: Fortran character types
+    integer
+
+        example option: num_lucky=5
+
+        description: generic integer type
+
+        usage: any integer-type input
+    logical
+
+        example option: l_spock=.true.
+
+        description: Fortran logical type - either .true. or .false.
+
+        usage: Fortran logical types
+    python_boolean
+
+        example option: ENABLE_THINGS=True
+
+        description: Python boolean type - either True or False
+
+        usage: Python boolean types
+    python_list
+
+        description: used to signify a Python-compatible formatted list such
+as ["Foo", 50, False]. This encapsulates length, so do not use a separate
+length declaration for this setting.
+
+        usage: use for inputs that expect a string that looks like a Python
+list - e.g. Jinja2 list input variables.
+    quoted
+
+        example option: js_measure_cloud_mode="laser"
+
+        description: a double quoted string, double quotes escaped with
+backslash
+
+        usage: Inputs that require double quotes and allow backslash escaping
+e.g. javascript/JSON inputs.
+    real
+
+        example option: n_avogadro=6.02e23
+
+        description: Fortran real number type, generic floating point numbers
+
+        usage: Fortran real types, generic floating point numbers. Scientific
+notation must use the "e" or "E" format.
+
+        comment: Internally implemented within Rose using Python's floating
+point specification.
+    raw
+
+        description: placeholder used in derived type specifications where
+none of the above types apply
+
+        usage: only in derived types
+    spaced_list
+
+        description: used to signify a space separated list such as "Foo" 50
+False.
+
+        usage: use for inputs that expect a string that contains a number of
+space separated items - e.g. in fcm_make app configs.
+
+    Note that not all inputs need to have type defined. In some cases using
+values or pattern is better.
+
+    A derived type may be defined by a comma , separated list of intrinsic
+types, e.g. integer, character, real, integer. The default is a raw string.
+length
+
+    Define the length of an array. If not present, the setting is assumed to
+be a scalar. A positive integer defines a fixed length array. A colon :
+defines a dynamic length array.
+
+    N.B. You do not need to use length if you already have type=python_list
+for a setting.
+element-titles
+
+    Define a list of comma separated "titles" to appear above array entries.
+If not present then no titles are displayed.
+
+    N.B. where the number of element-titles is greater than the length of the
+array, it will only display titles up to the length of the array.
+Additionally, where the associated array is longer than the number of
+element-titles, blank headings will be placed above them.
+values
+
+    Define a comma , separated list of permitted values of a setting (or an
+element in the setting if it is an array). This metadata overrides the type,
+range and pattern metadata.
+
+    For example, the config editor may use this list to determine the widget
+to display the setting. It may display the choices using a set of radio
+buttons if the list of values is small, or a drop down combo box if the list
+of values is large. If the list only contains one value, the config editor
+will expect the setting to always have this value, and may display it as a
+special setting.
+value-titles
+
+    Define a comma , separated list of titles to associate with each of the
+elements of values which will be displayed instead of the value. This list
+should contain the same number of elements as the values entry.
+
+    For example, given the following metadata:
+
+    [env=HEAT]
+    values=0, 1, 2
+    value-titles=low, medium, high
+
+    the config editor will display low for option value 0, medium for 1 and
+high for 2.
+value-hints
+
+    Define a comma , separated list of suggested values for a variable as
+value-hints, but still allows the user to provide their own override. This
+is like an auto-complete widget.
+
+    For example, given the following metadata:
+
+    [env=suggested_fruit]
+    value-hints=pineapple,cherry,banana,apple,pear,mango,kiwi,grapes,peach,fig,
+               =orange,strawberry,blackberry,blackcurrent,raspberry,melon,plum
+
+    the config editor will display possible option values when the user
+starts typing if they match a suggested value.
+range
+
+    Specify a range of values. It can either be a simple comma , separated
+list of allowed values, or a logical expression in the Rose metadata
+mini-language. This metadata is only valid if type is either integer or real.
+
+    A simple list may contain a mixture of allowed numbers and number ranges
+such as 1, 2, 4:8, 10:, (which means the value can be 1, 2, between 4 and 8
+inclusive, or any values greater than or equal to 10.)
+
+    A logical expression uses the Rose metadata mini-language, using the
+variable this to denote the value of the current setting, e.g. this <-1 and
+this >1. Inter-variable comparisons are not permitted (but see the fail-if
+property below for a way to implement this).
+pattern
+
+    Specify a regular expression (Python's extended regular expression
+syntax) to compare against the whole value of the setting.
+
+    For example, if we write the following metadata:
+
+    [namelist:cheese=country_of_origin]
+    pattern=^"[A-Z].+"$
+
+    then we expect all valid values for country_of_origin to start with a
+double quote (^"), begin with an uppercase letter ([A-Z]), contain some other
+characters or spaces (.+), and end with a quote ("$).
+
+    If you have an array variable (for example,
+TARTAN_PAINT_COLOURS='blue','red','blue') and you want to specify a pattern
+that each element of the array must match, you can construct a regular
+expression that repeats and includes commas. For example, if each element in
+our TARTAN_PAINT_COLOURS array must obey the regular expression 'red'|'blue',
+then we can write:
+
+    [env=TARTAN_PAINT_COLOURS]
+    length=:
+    pattern=^('red'|'blue')(?:,('red'|'blue'))*$
+
+fail-if, warn-if
+
+    Specify a logical expression using the Rose mini-language to validate the
+value of the current setting with respect to other settings. If the logical
+expression evaluates to true in a fail-if metadata, the system will consider
+the setting in error. On the other hand, in a warn-if metadata, the system
+will only issue a warning. The logical expression uses a Python-like syntax
+(documented fully in the appendix). It can reference the value of the current
+setting with the this variable and the value of other settings with their IDs.
+E.g.:
+
+    [namelist:test=my_test_var]
+    fail-if=this < namelist:test=control_lt_var;
+
+    means that an error will be flagged if the numeric value of my_test_var
+is less than the numeric value of control_lt_var.
+
+    fail-if=this != 1 + namelist:test=ctrl_var_1 *
+(namelist:test=ctrl_var_2 - this);
+
+    shows a more complex operation, again with numeric values.
+
+    To check array elements, the ID should be expressed with a bracketed
+index, as in the configuration:
+
+    fail-if=this(2) != "'0A'" and this(4) == "'0A'";
+
+    Array elements can also be checked using any and all. E.g.:
+
+    fail-if=any(namelist:test=ctrl_array < this);
+    fail-if=all(this == 0);
+
+    Similarly, the number of array elements can be checked using len. E.g.:
+
+    fail-if=len(namelist:test=ctrl_array) < this;
+    fail-if=len(this) == 0;
+
+    Expressions can be chained together and brackets used:
+
+    fail-if=this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or
+namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
+
+    Multiple failure conditions can be added, by using a semicolon as the
+separator - the semicolon is optional for a single statement or the last in a
+block, but is recommended. Multiple failure conditions are essentially similar
+to chaining them together with or, but the system can process each expression
+one by one to target the error message.
+
+    fail-if=this > 0; this % 2 == 1; this * 3 > 100;
+
+    You can add a message to the error or warning message to make it clearer
+by adding a hash followed by the comment at the end of a configuration
+metadata line:
+
+    fail-if=any(namelist:test=ctrl_array % this == 0); # Needs to be common
+divisor for ctrl_array
+
+    When using multiple failure conditions, different messages can be added
+if they are placed on individual lines:
+
+    fail-if=this > 0; # Needs to be less than or equal to 0
+            this % 2 == 1; # Needs to be odd
+            this * 3 > 100; # Needs to be more than 100/3.
+
+    A slightly different usage of this functionality can do things like
+warn of deprecated content:
+
+    warn-if=True;  # This option is deprecated
+
+    This would always evaluate True and give a warning if the setting is
+present.
+
+    Please note: when dividing a real-numbered setting by something, make
+sure that the expression does not actually divide an integer by an
+integer - for example, this / 2 will evaluate as 0 if this has a value of 1,
+but 0.5 if it has a value of 1.0. This is a result of Python's implicit
+typing.
+
+    You can get around this by making sure either the numerator or denominator 
+is a real number - e.g. by rewriting it as this / 2.0 or 1.0 * this / 2.
+
+Metadata for Behaviour
+^^^^^^^^^^^^^^^^^^^^^^
+
+These metadata are used to define how the setting should behave in different
+states.
+
+compulsory
+
+    A true value indicates that the setting should be compulsory. If this
+flag is not set, the setting is optional.
+
+    Compulsory sections should be physically present in the configuration at
+all times. Compulsory options should be physically present in the
+configuration if their parent section is physically present.
+
+    Optional settings can be removed as the user wishes. Compulsory settings
+may however be triggered ignored (see below). For example, the config editor
+may issue a warning if a compulsory setting is not defined. It may also hide
+a compulsory variable that only has a single permitted value.
+
+trigger
+
+    A setting has the following states:
+
+    * normal
+    * user ignored (stored in the configuration file with a ! flag, ignored
+      at run time)
+    * logically ignored (stored in the configuration file with a !! flag,
+      ignored at runtime)
+
+    If a setting is user ignored, the trigger will do nothing. Otherwise:
+
+    * If the logic for a setting in the trigger is fulfilled, it will cause
+      the setting to be enabled.
+    * If it is not, it will cause the setting to be logically ignored.
+
+    The trigger expression is a list of settings triggered by (different
+values of) this setting. If the values are not given, the setting will be
+triggered only if the current setting is enabled.
+
+    The syntax contains id-values pairs, where the values part is optional.
+Each pair must be separated by a semi-colon. Within each pair, any values
+must be separated from the id by a colon and a space (: ). Values must be
+formatted in the same way as the setting "values" defined above (i.e. comma
+separated).
+
+    The trigger syntax looks like:
+
+    [namelist:trig_nl=trigger_variable]
+    trigger=namelist:dep_nl=A;
+            namelist:dep_nl=B;
+            namelist:value_nl=X: 10;
+            env=Y: 20, 30, 40;
+            namelist:value_nl=Z: 20;
+
+    In this example:
+
+    * When namelist:trig_nl=trigger_variable is ignored, all the variables
+      in the trigger expression will be ignored, irrespective of its value.
+    * When namelist:trig_nl=trigger_variable is enabled, namelist:dep_nl=A
+      and namelist:dep_nl=B will both be enabled, and the other variables
+      may be enabled according to its value:
+      * When the value of the setting is not 10, 20, 30, or 40,
+        namelist:value_nl=X, env=Y and namelist:value_nl=Z will be ignored.
+      * When the value of the setting is 10, namelist:value_nl=X will be
+        enabled, but env=Y and namelist:value_nl=Z will be ignored.
+      * When the value of the setting is 20, env=Y and
+        namelist:value_nl=Z will be enabled, but namelist:value_nl=X will
+        be ignored.
+      * When the value of the setting is 30, env=Y will be enabled,
+        but namelist:value_nl=X and namelist:value_nl=Z will be ignored.
+      * If the value of the setting contains an environment
+        variable-like string, e.g. ${TEN_MULTIPLE}, all three will be enabled.
+
+    Settings mentioned in trigger expressions will have their default
+state set to ignored unless explicitly triggered. The config editor will
+issue warnings if variables or sections are in the incorrect state when it
+loads a configuration. Triggering thereafter will work as normal.
+
+    Where multiple triggers act on a setting, the setting is triggered only
+if all triggers are active (i.e. an AND relationship). For example, for
+the two triggers here:
+
+    [env=IS_WATER]
+    trigger=env=IS_ICE: true;
+
+    [env=IS_COLD]
+    trigger=env=IS_ICE: true;
+
+    the setting env=IS_ICE is only enabled if both env=IS_WATER and
+env=IS_COLD are true and enabled. Otherwise, it is ignored.
+
+    The trigger syntax also supports a logical expression using the Rose 
+metadata mini-language, in the same way as the range or fail-if metadata.
+As with range, inter-variable comparisons are disallowed.
+
+    [env=SNOWFLAKE_SIDES]
+    trigger=env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
+            env=SILLY_SNOWFLAKE_GEOMETRY: this < 2;
+
+    In this example, the setting env=CUSTOM_SNOWFLAKE_GEOMETRY is enabled
+if env=SNOWFLAKE_SIDES is enabled and not 6. env=SILLY_SNOWFLAKE_GEOMETRY is
+only enabled when env=SNOWFLAKE_SIDES is enabled and less than 2. The logical
+expression syntax can be used with non-numeric variables in the same way as
+the fail-if metadata.
+duplicate
+
+    Allow duplicated copies of the setting. This is used for sections where
+there may be more than one with the same metadata - for example multiple
+namelist groups of the same name. If this setting is true for a given name,
+the application configuration will accept multiple namelist groups of this
+name. The config editor may then provide the option to clone or copy a
+namelist to generate an additional namelist. Otherwise, the config editor
+may issue warning for configuration sections that are found with multiple
+copies or an index.
+macro
+
+    Associate a setting with a comma-delimited set of custom macros (but not
+upgrade macros).
+
+    E.g. for a macro class called FibonacciChecker in the metadata under
+lib/python/macros/fib.py, we may have:
+
+    macro=fib.FibonacciChecker
+
+    This may be used in the config editor to visually associate the setting
+with these macros. If a macro class has both a transform and a validate
+method, you can specify which you need by appending the method to the name
+e.g.:
+
+    macro=fib.Fibonacci.validate
+
+widget[gui-application]
+
+    Indicate that the gui-application (e.g. config-edit) should use a
+special widget to display this setting.
+
+    E.g. If we want to use a slider instead of an entry box for a floating
+point real number.
+
+    The widget may take space-delimited arguments which would be specified
+after the widget name. E.g. to set up a hypothetical table with named columns
+X, Y, VCT, and Level, we may do:
+
+    widget[rose-config-edit]=table.TableWidget X Y VCT Level
+
+    You may override to a Rose built-in widget by specifying a full rose
+class path in Python - for example, to always show radiobuttons for an option
+with values set:
+
+    widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
+
+    Another useful Rose built-in widget to use is the array element aligning
+page widget, rose.config_editor.pagewidget.table.PageArrayTable. You can set
+this for a section or namespace to make sure each nth variable value element
+lines up horizontally. For example:
+
+    [namelist:meal_choices]
+    customers='Athos','Porthos','Aramis','d''Artagnan'
+    entrees='soup','pate','soup','asparagus'
+    main='beef','spaghetti','coq au vin','lamb'
+    petits_fours=.false.,.true.,.false.,.true.
+
+    could use the following metadata:
+
+    [namelist:meal_choices]
+    widget[rose-config-edit]=rose.config_editor.pagewidget.table.PageArrayTable
+
+    to align the elements on the page like this:
+
+    customers        Athos      Porthos      Aramis      d'Artagnan
+    entrees          soup        pate         soup       asparagus
+    main             beef      spaghetti   coq au vin       lamb
+    petits_fours    .false.     .true.       .false.       .true.
+
+copy-mode (metadata usage with the rose-suite.info file)
+
+    Setting copy-mode in the metadata allows for the field to be either
+never copied or copied with any value associated to be clear.
+
+    For example: in a rose-suite.info file
+
+    [ensemble members]
+    copy-mode=never
+
+    Setting the ensemble members field to include copy-mode=never means
+that the ensemble members field would never be copied.
+
+    [additional info]
+    copy-mode=clear
+
+    Setting the additional info field to include copy-mode=never means that
+the additional info field would be copied, but any value associated with it
+would be cleared.
+
+Metadata for Help
+^^^^^^^^^^^^^^^^^
+
+These metadata provide help for a configuration.
+
+url
+
+    A web URL containing help for the setting. For example:
+
+    url=http://www.something.com/FOO/view/dev/doc/FOO.html
+
+    For example, the config editor will trigger a web browser to display this
+when a variable name is clicked. A partial URL can be used for variables if
+the variable's section or namespace has a relevant parent url property to use
+as a prefix. For example:
+
+    [namelist:foo]
+    url=https://www.google.com/search
+
+    [namelist:foo=bar]
+    url=?q=nearest+bar
+
+help
+
+    (Long) help for the setting. For example, the config editor will use
+this in a popup dialog for a variable. Embedding variable ids in the help
+string will allow links to the variables to be created within the popup
+dialog box, e.g.
+
+    help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test
+to do something linear.
+
+    Web URLs beginning with http:// will also be presented as links in the
+config editor.
+description
+
+    (Medium) description for the setting. For example, the configuration
+editor will use this as part of the hover over text.
+
+    The config editor will also use descriptions set for sections or
+namespaces as page header text (appears at the top of a panel or page),
+with clickable id and URL links as in help. Descriptions set for variables
+may be automatically shown underneath the variable name in the config editor,
+depending on view options.
+title
+
+    (Short) title for the setting. For example, the config editor can use
+this specification as the label of a setting, instead of the variable name.
+
+
+Appendix: Metadata Location
+---------------------------
+
+Centralised Rose metadata is referred to with either the meta or project
+top level flag in a configuration. It needs to live in a
+system-global-readable location.
+
+Rose utilities will do a path search for metadata using the following in
+order of precedence:
+
+* The --meta-path=PATH option of relevant commands.
+* The content of the ROSE_META_PATH environment variable.
+* The meta-path setting in site/user configurations.
+
+Each of the above settings can be a colon-separated list of paths.
+
+Underneath each directory in the search path should be a hierarchy like the
+following:
+
+${APP}/HEAD/
+${APP}/${VERSION}/
+${APP}/versions.py # i.e. the upgrade macros
+
+N.B. A Rose suite info is likely to have no versions.
+
+Note that, in some cases, a number of different executables may share the
+same application configuration metadata in which case APP is given a name
+which covers all the uses.
+
+The Rose team recommend placing metadata in a rose-meta directory at the
+top of a project's source tree. Central metadata, if any, at the meta-path
+location in the site configuration, should be a collection of
+regularly-updated subdirectories from all of the relevant projects' rose-meta
+directories.
+
+For example, a system CHOCOLATE may have a flat metadata structure within
+the repository:
+
+CHOCOLATE/doc/
+...
+CHOCOLATE/rose-meta/
+CHOCOLATE/rose-meta/choc-dark/
+CHOCOLATE/rose-meta/choc-milk/
+    
+
+and the system CAFFEINE may have a hybrid structure, with both flat and 
+hierarchical components:
+
+CAFFEINE/doc/
+...
+CAFFEINE/rose-meta/caffeine-guarana/
+CAFFEINE/rose-meta/caffeine-coffee/cappuccino/
+CAFFEINE/rose-meta/caffeine-coffee/latte/
+CAFFEINE/rose-meta/caffeine-tea/yorkshire/
+CAFFEINE/rose-meta/caffeine-tea/lapsang/
+
+and a site configuration with:
+
+meta-path=/path/to/rose-meta
+
+We would expect the following directories in /path/to/rose-meta:
+
+/path/to/rose-meta/caffeine-guarana/
+/path/to/rose-meta/caffeine-coffee/
+/path/to/rose-meta/caffeine-tea/
+/path/to/rose-meta/choc-dark/
+/path/to/rose-meta/choc-milk/
+
+with caffeine-coffee containing subdirectories cappuccino and latte, and
+caffeine-tea containing yorkshire and lapsang
+
+
+Appendix: Upgrade and Versions
+------------------------------
+
+Terminology:
+
+The HEAD (i.e. development) version
+    The configuration metadata most relevant to the latest revision of the
+source tree.
+A named version
+    The configuration metadata most relevant to a release, or a particular
+revision, of the software. This will normally be a copy of the HEAD version
+at a given revision, although it may be updated with some backward compatible
+fixes.
+
+Each change in the HEAD version that requires an upgrade procedure should
+introduce an upgrade macro. Each upgrade macro will provide the following
+information:
+
+* A tag of the configuration which can be applied by this macro (i.e. the
+  previous tag).
+* A tag of the configuration after the transformation.
+
+This allows our system to build up a chain if multiple upgrades need to be
+applied. The tag can be any name, but will normally refer to the ticket
+number that introduces the change.
+
+Every new upgrade macro creates a new tagged version. A named version is
+simply a tagged version for which a copy of the relevant configuration
+metadata is made available.
+
+Named versions for system releases are typically created at the end of the
+release process. The associated upgrade macro is typically only required in
+order to create the new name tag and, therefore, does not normally alter the
+application configuration.
+
+Application configurations can reference the configuration metadata as
+follows:
+
+#!cfg
+# Refer to the HEAD version
+# (typically you wouldn't do this since no upgrade process is possible)
+# For flat metadata
+meta=my-command
+# For hierarchical metadata
+meta=/path/to/metadata/my-command/HEAD
+
+# Refer to a named or tagged version in the flat metadata
+meta=my-command/8.3
+meta=my-command/t123
+# Refer to a named or tagged version in the hierarchical metadata
+meta=/path/to/metadata/my-command/8.3
+
+If a version is defined then the Rose utilities will first look for the
+corresponding named version. If this cannot be found then the HEAD version
+is used and, if an upgrade is available, a warning will be given to indicate
+that the configuration metadata being used requires upgrade macros to be run.
+If the version defined does not correspond to a tagged version then a warning
+will be given.
+
+Please note that if a hierarchical structure for the metadata is being used,
+the HEAD tag must be specified explictly.
+
+When to create named versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One option is to create a new named version for each release of your system.
+This makes it easy for users to understand. However, if there is a new
+release which does not require a change to the metadata then you will still
+have to create a new copy and force the user to go through a null upgrade
+which may not be desirable. An alternative is to only create a new named
+version at releases which require changes. The name then indicates the
+metadata is relevant for a particular release and all subsequent releases
+(unless an upgrade macro is available to a later release).
+
+It is also possible to make any tagged version between releases a named
+version, but it will usually be better not to. In which case, the user will
+be using HEAD and will be prompted to upgrade (which is probably what you
+want if you're not using a release).
+
+Sharing metadata between different executables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If 2 different commands share the majority of their inputs then you may
+choose to use the same configuration metadata for both commands. Any
+differences (in terms of available inputs) can then be triggered by the
+command in use. Whether this is desirable will partly depend on how many of
+the inputs are shared.
+
+One downside of sharing metadata is that your application configuration may
+contain (ignored) settings which have no relevance to the command you are
+using.
+
+Note that we intend to introduce support for configuration metadata to
+include / inherit from other metadata. This may mean that it makes sense to
+have separate metadata for different commands even when the majority of
+inputs are shared.
+
+Another reason you may want to share metadata is if you have 2 related
+commands which you want to configure using the same set of inputs (i.e. a
+single application configuration).
+
+This works by setting an alternate command in the application configuration
+and then using the `--command-key` option to `rose app-run`.
+
+Using development versions of upgrade macros
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users will be able to test out development versions of the upgrade macros by
+adding a working copy of the relevant branch into their metadata search path.
+However, care must be taken when doing this. Running the upgrade macro will
+change the `meta` setting to refer to the new tag. If the upgrade macro is
+subsequently changed or other upgrade macros are added to the chain prior to
+this tag (because they get committed to the trunk first) then this will
+result in application configurations which have not gone through the correct
+upgrade process. Therefore, when using development versions of the upgrade
+macros it is safest to not commit any resulting changes (or to use a branch
+of the suite which you are happy to discard).
+
+
+Appendix: Metadata Mini-Language
+--------------------------------
+
+The Rose metadata mini-language supports writing a logical expression in
+Python-like syntax, using variable ids to reference their associated values.
+
+Expressions are set as the value of metadata properties such as fail-if and
+range.
+
+The language is a small sub-set of Python - a limited set of operators is
+supported. No built-in object methods, functions, or modules are
+supported - neither are control blocks such as if/for, statements such as
+del or with, or defining your own functions or classes. Anything that
+requires that kind of power should be in proper Python code as a macro.
+
+Nevertheless, the language allows considerable power in terms of defining
+simple rules for variable values.
+
+Operators
+^^^^^^^^^
+
+The following numeric operators are supported:
+
++     # add
+-     # subtract
+*     # multiply
+**    # power or exponent - e.g. 2 ** 3 implies 8
+/     # divide
+//    # integer divide (floor) - e.g. 3 // 2 implies 1
+%     # remainder e.g. 5 % 3 implies 2
+
+The following string operators are supported:
+
++      # concatenate - e.g. "foo" + "bar" implies "foobar"
+*      # self-concatenate some number of times - e.g. "foo" * 2 implies
+         "foofoo"
+%      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
+in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
+not in # opposite sense of in
+
+# Where m, n are integers or expressions that evaluate to integers
+# (negative numbers count from the end of the string):
+[n]   # get nth character from string - e.g. "foo"[1] implies "o"
+[m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
+[m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies
+        "oobar"
+[:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
+
+The following logical operators are supported:
+
+and   # Logical AND
+or    # Logical OR
+not   # Logical NOT
+
+The following comparison operators are supported:
+
+is    # Is the same object as (usually used for 'is none')
+<     # Less than
+>     # Greater than
+==    # Equal to
+>=    # Greater than or equal to
+<=    # Less than or equal to
+!=    # Not equal to
+
+Operator precedence is intended to be the same as Python. However, with the
+current choice of language engine, the % and // operators may not obey
+this - make sure you force the correct behaviour using brackets.
+
+Constants
+^^^^^^^^^
+
+The following are special constants:
+
+None  # Python None
+False # Python False
+True  # Python True
+
+Using Variable Ids
+^^^^^^^^^^^^^^^^^^
+
+Putting a variable id in the expression means that when the expression
+is evaluated, the string value of the variable is cast and substituted into
+the expression.
+
+For example, if we have a configuration that looks like this:
+
+[namelist:zoo]
+num_elephants=2
+elephant_mood='peaceful'
+
+and an expression in the configuration metadata:
+
+namelist:zoo=elephant_mood != 'annoyed' and num_elephants >= 2
+
+then the expression would become:
+
+'peaceful' != 'annoyed' and 2 >= 2
+
+If the variable is not currently available (ignored or missing) then the
+expression cannot be evaluated. If inter-variable comparisons are not allowed
+for the expression's parent option (such as with trigger and range) then
+referencing other variable ids is not allowed.
+
+In this case the expression would be false.
+
+You may use this as a placeholder for the current variable id - for example,
+the fail-if expression:
+
+[namelist:foo=bar]
+fail-if=namelist:foo=bar > 100 and namelist:foo=bar % 2 == 1
+
+is the same as:
+
+[namelist:foo=bar]
+fail-if=this > 100 and this % 2 == 1
+
+Arrays
+^^^^^^
+
+The syntax has some special ways of dealing with variable values that are
+arrays - i.e. comma-separated lists.
+
+You can refer to a single element of the value for a given variable id
+(or this) by suffixing a number in round brackets - e.g.:
+
+namelist:foo=bar(2)
+
+references the second element in the value for bar in the section
+namelist:foo. This follows Fortran index numbering and syntax, which starts
+at 1 rather than 0 - i.e. referencing the 1st element in the array foo is
+written as foo(1).
+
+If we had a configuration:
+
+[namelist:foo]
+bar='a', 'b', 'c', 'd'
+
+namelist:foo=bar(2) would get substituted in an expression with 'b' when the
+expression was evaluated. For example, an expression that contained:
+
+namelist:foo=bar(2) == 'c'
+
+would be evaluated as:
+
+'b' == 'c'
+
+Should you wish to make use of the array length in an expression you can
+make use of the len function, which behaves in the same manner as its
+Python and Fortran equivalents to return the array length. For example:
+
+len(namelist:foo=bar) > 3
+
+would be expanded to:
+
+4 > 3
+
+and evaluate as true.
+
+There are two other special array functions, any and all, which behave in
+a similar fashion to their Python and Fortran equivalents, but have a
+different syntax.
+
+They allow you to write a shorthand expression within an any() or all()
+bracket which implies a loop over each array element. For example:
+
+any(namelist:foo=bar == 'e')
+
+evaluates true if any elements in the value of bar in the section
+namelist:foo are 'e'. For the above configuration snippet, this would be
+expanded before evaluation to be:
+
+'a' == 'e' or 'b' == 'e' or 'c' == 'e' or 'd' == 'e'
+
+Similarly,
+
+all(namelist:foo=bar == 'e')
+
+evaluates true if all elements are 'e'. Again, with the above configuration,
+this would be expanded before proper evaluation:
+
+'a' == 'e' and 'b' == 'e' and 'c' == 'e' and 'd' == 'e'
+
+Internals
+^^^^^^^^^
+
+Rose uses an external engine to evaluate the raw language string after
+variable ids and any any() and all() functions have been substituted and
+expanded.
+
+The current choice of engine is Jinja2, which is responsible for the
+details of the supported Pythonic syntax. This may change.
+
+Do not use any Jinja2-specific syntax.
+
+
+Appendix: Config Editor Ignored Mechanics
+-----------------------------------------
+
+This describes the intended behaviour of the config editor when there is
+an ignored state mismatch for a setting - e.g. a setting might be enabled
+when it should be trigger-ignored.
+
+The config editor differs from the strict command line macro equivalent
+because the Switch Off Metadata mode and accidentally metadata-less
+configurations need to be presented in a nice way without lots of
+not-necessarily-errors. The config editor should only report the errors
+where the state is definitely wrong or makes a material difference to the user.
+
+The table contains error and fixing information for some varieties of
+ignored state mismatches. The actual situations are considerably more
+varied, given section-ignoring and latent variables - the table holds
+the most important varieties.
+
+The State contains the actual states. The Trigger State column contains
+the trigger-mechanism's expected states. The states can be:
+
+IT - !!
+    trigger ignored
+IU - !
+    user ignored
+E - (normal)
+    enabled

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -40,7 +40,8 @@ of precedence:
 * The ``meta-path`` setting in :ref:`site/user <site-n-user-conf>`
   configurations.
 
-See :ref:`app-meta-loc` for more details.
+.. tip::
+   See :ref:`app-meta-loc` for more details.
 
 The configuration metadata that controls default behaviour will be located in
 ``$ROSE_HOME/etc/rose-meta/``.
@@ -145,8 +146,8 @@ ns
   they can be placed in different pages. A namespace for a section will
   become the default for all the settings in that section.
 
-  Note that you should not assign namespaces to variables in duplicate
-  sections.
+  .. note::
+     You should not assign namespaces to variables in duplicate sections.
 
 sort-key
   A character string that can be used as a sort key for ordering an option
@@ -234,8 +235,11 @@ type
 
   ``python_list``
     *description*: used to signify a Python-compatible formatted list such
-    as ``["Foo", 50, False]``. This encapsulates ``length``, so do not use a
-    separate ``length`` declaration for this setting.
+    as ``["Foo", 50, False]``.
+    
+    .. warning::
+       This encapsulates ``length``, so do not use a
+       separate ``length`` declaration for this setting.
 
     *usage*: use for inputs that expect a string that looks like a Python
     list - e.g. Jinja2 list input variables.
@@ -254,8 +258,10 @@ type
      
      *description*: Fortran real number type, generic floating point numbers
 
-     *usage*: Fortran real types, generic floating point numbers. Scientific
-     notation must use the "e" or "E" format.
+     *usage*: Fortran real types, generic floating point numbers.
+     
+     .. note::
+        Scientific notation must use the "e" or "E" format.
 
      *comment*: Internally implemented within Rose using Python's
      `floating point`_ specification.
@@ -273,8 +279,9 @@ type
     *usage*: use for inputs that expect a string that contains a number of
     space separated items - e.g. in ``fcm_make`` app configs.
 
-  Note that not all inputs need to have ``type`` defined. In some cases
-  using ``values`` or ``pattern`` is better.
+    .. note::
+       Not all inputs need to have ``type`` defined. In some cases using
+       ``values`` or ``pattern`` is better.
 
   A derived type may be defined by a comma ``,`` separated list of intrinsic
   types, e.g. ``integer, character, real, integer``. The default is a raw
@@ -285,17 +292,19 @@ length
   be a scalar. A positive integer defines a fixed length array. A colon ``:``
   defines a dynamic length array.
 
-  N.B. You do not need to use ``length`` if you already have
-  ``type=python_list`` for a setting.
+  .. note::
+     You do not need to use ``length`` if you already have
+     ``type=python_list`` for a setting.
 
 element-titles
   Define a list of comma separated "titles" to appear above array entries.
   If not present then no titles are displayed.
 
-  N.B. where the number of element-titles is greater than the length of the
-  array, it will only display titles up to the length of the array.
-  Additionally, where the associated array is longer than the number of
-  element-titles, blank headings will be placed above them.
+  .. note::
+     Where the number of element-titles is greater than the length of the
+     array, it will only display titles up to the length of the array.
+     Additionally, where the associated array is longer than the number of
+     element-titles, blank headings will be placed above them.
 
 values
   Define a comma ``,`` separated list of permitted values of a setting (or an
@@ -354,8 +363,10 @@ range
   A logical expression uses the Rose metadata
   :ref:`mini-language <app-meta-mini-lang>`, using the variable ``this`` to
   denote the value of the current setting, e.g. ``this <-1 and this >1``.
-  Inter-variable comparisons are not permitted (but see the ``fail-if``
-  property below for a way to implement this).
+
+  .. warning::
+     Inter-variable comparisons are not permitted (but see the ``fail-if``
+     property below for a way to implement this).
 
 pattern
   Specify a regular expression (Python's extended regular expression
@@ -476,15 +487,16 @@ fail-if, warn-if
   This would always evaluate ``True`` and give a warning if the setting is
   present.
 
-  Please note: when dividing a real-numbered setting by something, make
-  sure that the expression does not actually divide an integer by an
-  integer - for example, ``this / 2`` will evaluate as ``0`` if ``this`` has
-  a value of ``1``, but ``0.5`` if it has a value of ``1.0``. This is a
-  result of Python's implicit typing.
+  .. note::
+     When dividing a real-numbered setting by something, make
+     sure that the expression does not actually divide an integer by an
+     integer - for example, ``this / 2`` will evaluate as ``0`` if ``this``
+     has a value of ``1``, but ``0.5`` if it has a value of ``1.0``. This is
+     a result of Python's implicit typing.
 
-  You can get around this by making sure either the numerator or denominator 
-  is a real number - e.g. by rewriting it as ``this / 2.0`` or
-  ``1.0 * this / 2``.
+     You can get around this by making sure either the numerator or
+     denominator is a real number - e.g. by rewriting it as ``this / 2.0`` or
+     ``1.0 * this / 2``.
 
 Metadata for Behaviour
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -795,20 +807,23 @@ following:
       ${APP}/${VERSION}/
       ${APP}/versions.py # i.e. the upgrade macros
 
-N.B. A Rose suite info is likely to have no versions.
+.. note::
+   A Rose suite info is likely to have no versions.
 
-Note that, in some cases, a number of different executables may share the
-same application configuration metadata in which case APP is given a name
-which covers all the uses.
+.. note::
+   In some cases, a number of different executables may share the
+   same application configuration metadata in which case APP is given a
+   name which covers all the uses.
 
-The Rose team recommend placing metadata in a ``rose-meta`` directory at the
-top of a project's source tree. Central metadata, if any, at the
-``meta-path`` location in the site configuration, should be a collection of
-regularly-updated subdirectories from all of the relevant projects'
-``rose-meta`` directories.
+.. tip::
+   The Rose team recommend placing metadata in a ``rose-meta`` directory at
+   the top of a project's source tree. Central metadata, if any, at the
+   ``meta-path`` location in the site configuration, should be a collection
+   of regularly-updated subdirectories from all of the relevant projects'
+   ``rose-meta`` directories.
 
-For example, a system ``CHOCOLATE`` may have a flat metadata structure
-within the repository:
+   For example, a system ``CHOCOLATE`` may have a flat metadata structure
+   within the repository:
 
    .. code-block:: bash
 
@@ -819,8 +834,8 @@ within the repository:
       CHOCOLATE/rose-meta/choc-milk/
     
 
-and the system ``CAFFEINE`` may have a hybrid structure, with both flat and
-hierarchical components:
+   and the system ``CAFFEINE`` may have a hybrid structure, with both flat
+   and hierarchical components:
 
    .. code-block:: bash
 
@@ -832,13 +847,13 @@ hierarchical components:
       CAFFEINE/rose-meta/caffeine-tea/yorkshire/
       CAFFEINE/rose-meta/caffeine-tea/lapsang/
 
-and a site configuration with:
+   and a site configuration with:
 
    .. code-block:: rose
 
       meta-path=/path/to/rose-meta
 
-We would expect the following directories in ``/path/to/rose-meta``:
+   We would expect the following directories in ``/path/to/rose-meta``:
 
    .. code-block:: bash
 
@@ -848,8 +863,8 @@ We would expect the following directories in ``/path/to/rose-meta``:
       /path/to/rose-meta/choc-dark/
       /path/to/rose-meta/choc-milk/
 
-with ``caffeine-coffee`` containing subdirectories ``cappuccino`` and
-``latte``, and ``caffeine-tea`` containing ``yorkshire`` and ``lapsang``.
+   with ``caffeine-coffee`` containing subdirectories ``cappuccino`` and
+   ``latte``, and ``caffeine-tea`` containing ``yorkshire`` and ``lapsang``.
 
 
 Appendix: Upgrade and Versions
@@ -914,8 +929,9 @@ that the configuration metadata being used requires upgrade macros to be run.
 If the version defined does not correspond to a tagged version then a warning
 will be given.
 
-Please note that if a hierarchical structure for the metadata is being used,
-the ``HEAD`` tag must be specified explictly.
+.. note::
+   If a hierarchical structure for the metadata is being used,
+   the ``HEAD`` tag must be specified explictly.
 
 When to create named versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -929,10 +945,11 @@ version at releases which require changes. The name then indicates the
 metadata is relevant for a particular release and all subsequent releases
 (unless an upgrade macro is available to a later release).
 
-It is also possible to make any tagged version between releases a named
-version, but it will usually be better not to. In which case, the user will
-be using HEAD and will be prompted to upgrade (which is probably what you
-want if you're not using a release).
+.. tip::
+   It is also possible to make any tagged version between releases a named
+   version, but it will usually be better not to. In which case, the user
+   will be using HEAD and will be prompted to upgrade (which is probably what
+   you want if you're not using a release).
 
 Sharing metadata between different executables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -947,10 +964,11 @@ One downside of sharing metadata is that your application configuration may
 contain (ignored) settings which have no relevance to the command you are
 using.
 
-Note that we intend to introduce support for configuration metadata to
-include / inherit from other metadata. This may mean that it makes sense to
-have separate metadata for different commands even when the majority of
-inputs are shared.
+.. note::
+   We intend to introduce support for configuration metadata to
+   include / inherit from other metadata. This may mean that it makes sense
+   to have separate metadata for different commands even when the majority
+   of inputs are shared.
 
 Another reason you may want to share metadata is if you have 2 related
 commands which you want to configure using the same set of inputs (i.e. a
@@ -986,11 +1004,14 @@ Expressions are set as the value of metadata properties such as ``fail-if``
 and ``range``.
 
 The language is a small sub-set of Python - a limited set of operators is
-supported. No built-in object methods, functions, or modules are
-supported - neither are control blocks such as ``if``\/``for``, statements
-such as ``del`` or ``with``, or defining your own functions or classes.
-Anything that requires that kind of power should be in proper Python code
-as a macro.
+supported.
+
+.. warning::
+   No built-in object methods, functions, or modules are
+   supported - neither are control blocks such as ``if``\/``for``, statements
+   such as ``del`` or ``with``, or defining your own functions or classes.
+   Anything that requires that kind of power should be in proper Python code
+   as a macro.
 
 Nevertheless, the language allows considerable power in terms of defining
 simple rules for variable values.
@@ -1209,7 +1230,8 @@ and expanded.
 The current choice of engine is `Jinja2`_, which is responsible for the
 details of the supported Pythonic syntax. This may change.
 
-**Do not use any Jinja2-specific syntax.**
+.. warning::
+   **Do not** use any Jinja2-specific syntax.
 
 
 Appendix: Config Editor Ignored Mechanics

--- a/sphinx/user-guide/configuration-metadata.rst
+++ b/sphinx/user-guide/configuration-metadata.rst
@@ -1,3 +1,12 @@
+.. include:: ../hyperlinks.rst
+   :start-line: 1
+
+.. _floating point: https://docs.python.org/3/library/stdtypes.html#typesnumeric
+.. _cast: https://docs.python.org/2/library/ast.html#ast.literal_eval
+
+.. _conf-meta:
+
+
 Configuration Metadata
 ======================
 
@@ -5,13 +14,13 @@ Configuration Metadata
 Format and Location
 -------------------
 
-See Configuration Format.
+See :ref:`conf-format`.
 
 A configuration metadata is itself a configuration. Each configuration
 metadata is represented in a directory with the following:
 
 * ``rose-meta.conf``, the main configuration file. See for detail.
-* ``opt/`` directory. For detail, see Optional Configuration.
+* ``opt/`` directory. For detail, see :ref:`opt-config`.
 * other files, e.g.:
 
   * ``lib/python/widget/my_widget.py`` would be the location of a custom
@@ -28,9 +37,10 @@ of precedence:
   application.
 * The ``--meta-path=PATH`` option of relevant commands.
 * The value of the ``ROSE_META_PATH`` environment variable.
-* The ``meta-path`` setting in site/user configurations.
+* The ``meta-path`` setting in :ref:`site/user <site-n-user-conf>`
+  configurations.
 
-See Metadata Location for more details.
+See :ref:`app-meta-loc` for more details.
 
 The configuration metadata that controls default behaviour will be located in
 ``$ROSE_HOME/etc/rose-meta/``.
@@ -247,8 +257,8 @@ type
      *usage*: Fortran real types, generic floating point numbers. Scientific
      notation must use the "e" or "E" format.
 
-     *comment*: Internally implemented within Rose using Python's floating
-     point specification.
+     *comment*: Internally implemented within Rose using Python's
+     `floating point`_ specification.
 
   ``raw``
     *description*: placeholder used in derived type specifications where
@@ -334,17 +344,18 @@ value-hints
 range
   Specify a range of values. It can either be a simple comma ``,`` separated
   list of allowed values, or a logical expression in the Rose metadata
-  mini-language. This metadata is only valid if ``type`` is either ``integer``
-  or ``real``.
+  :ref:`mini-language <app-meta-mini-lang>`. This metadata is only valid if
+  ``type`` is either ``integer`` or ``real``.
 
   A simple list may contain a mixture of allowed numbers and number ranges
   such as ``1, 2, 4:8, 10:`` (which means the value can be 1, 2, between 4
   and 8 inclusive, or any values greater than or equal to 10.)
 
-  A logical expression uses the Rose metadata mini-language, using the
-  variable ``this`` to denote the value of the current setting, e.g.
-  ``this <-1 and this >1``. Inter-variable comparisons are not permitted
-  (but see the ``fail-if`` property below for a way to implement this).
+  A logical expression uses the Rose metadata
+  :ref:`mini-language <app-meta-mini-lang>`, using the variable ``this`` to
+  denote the value of the current setting, e.g. ``this <-1 and this >1``.
+  Inter-variable comparisons are not permitted (but see the ``fail-if``
+  property below for a way to implement this).
 
 pattern
   Specify a regular expression (Python's extended regular expression
@@ -375,14 +386,16 @@ pattern
      pattern=^('red'|'blue')(?:,('red'|'blue'))*$
 
 fail-if, warn-if
-  Specify a logical expression using the Rose mini-language to validate the
+  Specify a logical expression using the Rose
+  :ref:`mini-language <app-meta-mini-lang>` to validate the
   value of the current setting with respect to other settings. If the logical
   expression evaluates to true in a ``fail-if`` metadata, the system will
   consider the setting in error. On the other hand, in a ``warn-if`` metadata,
   the system will only issue a warning. The logical expression uses a
-  Python-like syntax (documented fully in the appendix). It can reference the
-  value of the current setting with the ``this`` variable and the value of
-  other settings with their IDs. E.g.:
+  Python-like syntax (documented fully in the
+  :ref:`appendix <app-meta-mini-lang>`). It can reference the value of the
+  current setting with the ``this`` variable and the value of other settings
+  with their IDs. E.g.:
 
   .. code-block:: rose
 
@@ -573,8 +586,9 @@ trigger
   ``env=IS_COLD`` are ``true`` and enabled. Otherwise, it is ignored.
 
   The trigger syntax also supports a logical expression using the Rose 
-  metadata mini-language, in the same way as the ``range`` or ``fail-if``
-  metadata. As with ``range``, inter-variable comparisons are disallowed.
+  metadata :ref:`mini-language <app-meta-mini-lang>`, in the same way as
+  the ``range`` or ``fail-if`` metadata. As with ``range``, inter-variable
+  comparisons are disallowed.
 
   .. code-block:: rose
 
@@ -642,10 +656,11 @@ widget[gui-application]
 
      widget[rose-config-edit]=rose.config_editor.valuewidget.radiobuttons.RadioButtonsValueWidget
 
-  Another useful Rose built-in widget to use is the array element aligning
-  page widget, ``rose.config_editor.pagewidget.table.PageArrayTable``. You
-  can set this for a section or namespace to make sure each nth variable
-  value element lines up horizontally. For example:
+  Another useful Rose built-in widget to use is the array element
+  aligning :ref:`page widget <conf-ed-cust-pages>`,
+  ``rose.config_editor.pagewidget.table.PageArrayTable``. You can set this
+  for a section or namespace to make sure each *n* th variable value element
+  lines up horizontally. For example:
 
   .. code-block:: rose
 
@@ -747,6 +762,8 @@ title
   this specification as the label of a setting, instead of the variable name.
 
 
+.. _app-meta-loc:
+
 Appendix: Metadata Location
 ---------------------------
 
@@ -759,7 +776,8 @@ order of precedence:
 
 * The ``--meta-path=PATH`` option of relevant commands.
 * The content of the ``ROSE_META_PATH`` environment variable.
-* The ``meta-path`` setting in site/user configurations.
+* The ``meta-path`` setting in :ref:`site/user <site-n-user-conf>`
+  configurations.
 
 Each of the above settings can be a colon-separated list of paths.
 
@@ -799,7 +817,7 @@ within the repository:
 and the system ``CAFFEINE`` may have a hybrid structure, with both flat and
 hierarchical components:
 
-   .. code-block:: rose
+   .. code-block:: bash
 
       CAFFEINE/doc/
       ...
@@ -951,6 +969,8 @@ macros it is safest to not commit any resulting changes (or to use a branch
 of the suite which you are happy to discard).
 
 
+.. _app-meta-mini-lang:
+
 Appendix: Metadata Mini-Language
 --------------------------------
 
@@ -975,7 +995,7 @@ Operators
 
 The following *numeric* operators are supported:
 
-   .. code-block:: rose
+   .. code-block:: python
 
       +     # add
       -     # subtract
@@ -987,7 +1007,7 @@ The following *numeric* operators are supported:
 
 The following *string* operators are supported:
 
-   .. code-block:: rose
+   .. code-block:: python
 
       +      # concatenate - e.g. "foo" + "bar" implies "foobar"
       *      # self-concatenate some number of times - e.g. "foo" * 2 implies "foofoo"
@@ -998,14 +1018,15 @@ The following *string* operators are supported:
       # Where m, n are integers or expressions that evaluate to integers
       # (negative numbers count from the end of the string):
       [n]   # get nth character from string - e.g. "foo"[1] implies "o"
-      [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
+      [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies
+            # "ooba"
       [m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies
-        "oobar"
+            # "oobar"
       [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
 
 The following *logical* operators are supported:
 
-   .. code-block:: rose
+   .. code-block:: python
 
       and   # Logical AND
       or    # Logical OR
@@ -1013,7 +1034,7 @@ The following *logical* operators are supported:
 
 The following *comparison* operators are supported:
 
-   .. code-block:: rose
+   .. code-block:: python
 
       is    # Is the same object as (usually used for 'is none')
       <     # Less than
@@ -1032,7 +1053,7 @@ Constants
 
 The following are special constants:
 
-   .. code-block:: rose
+   .. code-block:: python
 
       None  # Python None
       False # Python False
@@ -1042,8 +1063,8 @@ Using Variable Ids
 ^^^^^^^^^^^^^^^^^^
 
 Putting a variable id in the expression means that when the expression
-is evaluated, the string value of the variable is cast and substituted into
-the expression.
+is evaluated, the string value of the variable is `cast`_ and substituted
+into the expression.
 
 For example, if we have a configuration that looks like this:
 
@@ -1180,7 +1201,7 @@ Rose uses an external engine to evaluate the raw language string after
 variable ids and any ``any()`` and ``all()`` functions have been substituted
 and expanded.
 
-The current choice of engine is Jinja2, which is responsible for the
+The current choice of engine is `Jinja2`_, which is responsible for the
 details of the supported Pythonic syntax. This may change.
 
 **Do not use any Jinja2-specific syntax.**

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -53,7 +53,7 @@ following:
 
 We have added the following conventions into our INI format:
 
-#. The file name is normally called ``rose\*.conf``, e.g. ``rose.conf``,
+#. The file name is normally called ``rose*.conf``, e.g. ``rose.conf``,
    ``rose-app.conf``, ``rose-meta.conf``, etc.
 #. Only a hash ``#`` in the beginning of a line starts a comment. Empty lines
    and lines with only white spaces are ignored. There is no support for
@@ -74,7 +74,7 @@ We have added the following conventions into our INI format:
 #. Only the equal sign ``=`` is used to delimit a key-value pair - because the 
    colon ``:`` may be used in keys of namelist declarations.
 #. A key-value pair declaration does not have to live under a section 
-   declaration. Such a declaration lives directly under the root level.
+   declaration. Such a declaration lives directly under the *root* level.
 #. Key-value pair declarations following a line with only ``[]`` are placed 
    directly under the root level.
 #. Declarations are case sensitive. When dealing with case-insensitive
@@ -96,9 +96,9 @@ We have added the following conventions into our INI format:
    * E.g. It will be ignored in run time but may be used by other Rose
      utilities.
    * A single exclamation denotes a user-ignored setting.
-   * A double exclamation denotes a program-ignored setting. E.g. rose
-     config-edit may use a double exclamation to switch off a setting
-     according to the setting metadata.
+   * A double exclamation denotes a program-ignored setting. E.g.
+     ``rose config-edit`` may use a double exclamation to switch off a
+     setting according to the setting metadata.
 
 #. The open square bracket (``[``) and close square bracket (``]``) characters
    cannot be used within a section declaration. E.g.
@@ -112,6 +112,8 @@ We have added the following conventions into our INI format:
    not assume order of environment variables.
 #. Values of settings accept syntax such as ``$NAME`` or ``${NAME}`` for
    environment variable substitution.
+
+E.g.
 
    .. code-block:: rose
 
@@ -195,7 +197,7 @@ Some Rose utilities (e.g. :ref:`command-rose-suite-run`,
 :ref:`command-rose-task-run`, :ref:`command-rose-app-run`, etc) allow
 optional configurations to be selected at run time using:
 
-#. The ROSE_APP_OPT_CONF_KEYS Environment variables.
+#. The ``ROSE_APP_OPT_CONF_KEYS`` Environment variables.
 #. The command line options ``--opt-conf-key=KEY`` or ``-O KEY``.
 
 See reference of individual commands for detail.
@@ -272,14 +274,14 @@ configuration in the user configuration overrides the site configuration and
 the default. Rose expects these files to be in the modified INI format
 described above. Rose utilities search for its site configuration at
 ``$ROSE_HOME/etc/rose.conf`` where ``$ROSE_HOME/bin/rose`` is the location of
-the rose command, and they search for the user configuration at
+the ``rose`` command, and they search for the user configuration at
 ``$HOME/.metomi/rose.conf`` where ``$HOME`` is the home directory of the
 current user.
 
-Allowed settings in the site and user configuration files will be documented
+*Allowed settings in the site and user configuration files will be documented
 in a future version of this document. In the mean time, the settings are 
-documented as comments in the ``etc/rose.conf.example`` file of each
-distribution of Rose.
+documented as comments in the* ``etc/rose.conf.example`` *file of each
+distribution of Rose.*
 
 You can also override many internal constants of the ``rose config edit`` and
 ``rosie go``. To change the keyboard shortcut of the ``Find Next`` action in
@@ -337,7 +339,7 @@ and root level options:
   invoked. However, it is unsafe to reference other environment variables
   defined in this section. If the value of an environment variable setting
   begins with a  tilde ``~``, all of the characters preceding the 1st slash
-  ``/`` are considered a tilde-prefix. Where possible, a tilde-prefix is
+  ``/`` are considered a *tilde-prefix*. Where possible, a tilde-prefix is
   replaced with the home  directory associated with the specified login name
   at run time. There are 2  special environment variables which can be
   specified in this section:
@@ -455,7 +457,7 @@ contain the following:
   * the command(s) to run.
   * the metadata type for the application.
   * the list of environment variables.
-  * other configurations that can be represented in un-ordered key=value
+  * other configurations that can be represented in un-ordered ``key=value``
     pairs, e.g. Fortran namelists.
 
 * ``file/`` directory: other input files, e.g.:
@@ -536,7 +538,7 @@ keys can be:
   time. It can be used to indicate that a value must be overridden at run
   time. If the value of an environment variable setting begins with a tilde
   ``~``, all of the characters preceding the 1st slash ``/`` are considered a
-  tilde-prefix. Where possible, a tilde-prefix is replaced with the home
+  *tilde-prefix*. Where possible, a tilde-prefix is replaced with the home
   directory associated with the specified login name at run time.
 
 ``[etc]``
@@ -580,14 +582,17 @@ keys can be:
   Specify prerequisites to poll for before running the actual application.
   3 types of tests can be performed:
 
-  ``all-files``: A list of space delimited list of file paths. This test
-  passes only if all file paths in the list exist.
+  ``all-files``
+    A list of space delimited list of file paths. This test
+    passes only if all file paths in the list exist.
 
-  ``any-files``: A list of space delimited list of file paths. This test
-  passes if any file path in the list exists.
+  ``any-files``
+    A list of space delimited list of file paths. This test
+    passes if any file path in the list exists.
 
-  ``test``: A shell command. This test passes if the command returns a 0
-  (zero) return code.
+  ``test``
+    A shell command. This test passes if the command returns a 0
+    (zero) return code.
 
   Normally, the ``all-files`` and ``any-files`` tests both test for the
   existence of file paths. If this is not enough, e.g. you want to test for
@@ -677,11 +682,12 @@ A ``[file:TARGET]`` section may have the following settings:
   section with a supported scheme in the current configuration, e.g. a
   ``namelist:NAME section``. Otherwise the URI must be in a supported scheme
   or be given sufficient information for the system to determine its scheme,
-  e.g. via the root level ``schemes`` setting described below. Normally, a
-  source that does not exist would trigger an error in run time. However, it
-  may be useful to have an optional source for a file sometimes. In which
-  case, the syntax ``source=(SOURCE)`` can be used to specify an optional
-  source. E.g. ``source=namelist:foo`` ``(namelist:bar)`` would allow
+  e.g. via the root level ``schemes`` setting described below.
+
+  Normally, a source that does not exist would trigger an error in run time.
+  However, it may be useful to have an optional source for a file sometimes.
+  In which case, the syntax ``source=(SOURCE)`` can be used to specify an
+  optional source. E.g. ``source=namelist:foo (namelist:bar)`` would allow
   ``namelist:bar`` to be missing or ignored without an error.
 
 ``checksum``
@@ -692,32 +698,32 @@ A ``[file:TARGET]`` section may have the following settings:
   checksum tells the system to report the target checksum in verbose mode.
 
 ``mode``
-  ``auto`` (default), ``mkdir``, ``symlink`` or ``symlink+``. See below.
+  ``auto`` (default), ``mkdir``, ``symlink`` or ``symlink+``.
 
-The following is a list of all the supported usages:
+  The following is a list of all the supported usages:
 
-``mode=auto,source=``
-  Target is an empty file.
+  ``mode=auto,source=``
+    Target is an empty file.
 
-``mode=auto,source=SOURCE``
-  Target is a copy of ``SOURCE``.
+  ``mode=auto,source=SOURCE``
+    Target is a copy of ``SOURCE``.
 
-``mode=auto,source=SOURCE-LIST``
-  Target is created by concatenating the contents of ``SOURCE-LIST``. The
-  sources should either be all files or all directories.
+  ``mode=auto,source=SOURCE-LIST``
+    Target is created by concatenating the contents of ``SOURCE-LIST``. The
+    sources should either be all files or all directories.
 
-``mode=mkdir``
-  Target is a directory.
+  ``mode=mkdir``
+    Target is a directory.
 
-``mode=symlink,source=SOURCE``
-  Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
-  ``SOURCE`` must be a single source. ``SOURCE`` does not have to exist when
-  the symbolic link is created.
+  ``mode=symlink,source=SOURCE``
+    Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
+    ``SOURCE`` must be a single source. ``SOURCE`` does not have to exist when
+    the symbolic link is created.
 
-``mode=symlink+,source=SOURCE``
-  Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
-  ``SOURCE`` must be a single source. ``SOURCE`` must exist when the symbolic
-  link is created.
+  ``mode=symlink+,source=SOURCE``
+    Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
+    ``SOURCE`` must be a single source. ``SOURCE`` must exist when the symbolic
+    link is created.
 
 The root level ``schemes`` setting: While the system would attempt to
 automatically detect the scheme of a source, the name of the source can
@@ -786,12 +792,12 @@ root directory to install file targets with a relative path:
 Appendix: rose-ana configuration format
 ---------------------------------------
 
-The ``rose-ana`` builtin application reads information about which analysis
+The ``rose-ana`` built-in application reads information about which analysis
 steps it should perform from the ``rose-app.conf`` file for that task. Each
 of the section names (in square brackets) which describe an analysis step
 must follow a particular format:
 
-* the name must begin with ``ana``:. This is required for ``rose-ana`` to
+* the name must begin with ``ana:``. This is required for ``rose-ana`` to
   recognise it as a valid section.
 * the next part gives the name of the class within one of the analysis
   modules, including namespace information; for example to use the built-in
@@ -803,7 +809,7 @@ must follow a particular format:
 
 The content within each of these sections consists of a series of key-value
 option pairs; just like other standard Rose apps. However the availability
-of options for a given section is specified and controlled by the class
+of options for a given section is specified and controlled by the *class*
 rather than the meta-data. This makes it easy to provide your own analysis
 modules without requiring changes to Rose itself.
 
@@ -812,14 +818,14 @@ analysis module you wish to use for details of which options it supports.
 Additionally, some special treatment is applied to all options depending
 on what they contain:
 
-* **Environment vars**: If the option contains any words prefixed by ``$`` they
-  will be substituted for the equivalent environment variable, if one is
-  available.
+* **Environment vars**: If the option contains any words prefixed by ``$``
+  they will be substituted for the equivalent environment variable, if one
+  is available.
 * **Lists**: If the option contains newlines it will be returned as a list of
   strings automatically.
-* **Argument substitution**: If the option contains one or more pairs of empty
-  curved-parentheses ``{}`` the option will be returned multiple times with
-  the parentheses substituted once for each argument passed to
+* **Argument substitution**: If the option contains one or more pairs of
+  empty curved-parentheses ``{}`` the option will be returned multiple times
+  with the parentheses substituted once for each argument passed to
   ``rose task-run``
 
 The app may also define a configuration section; ``[ana:config]``, whose

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -118,37 +118,37 @@ We have added the following conventions into our INI format:
 
 E.g.
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      # This is line 1 of the comment for this file.
-      # This is line 2 of the comment for this file.
+   # This is line 1 of the comment for this file.
+   # This is line 2 of the comment for this file.
 
-      # This comment will be ignored.
+   # This comment will be ignored.
 
-      # This is a comment for section-1.
-      [section-1]
-      # This is a comment for key-1.
-      key-1=value 1
-      # This comment will be ignored.
+   # This is a comment for section-1.
+   [section-1]
+   # This is a comment for key-1.
+   key-1=value 1
+   # This comment will be ignored.
 
-      # This is line 1 of the comment for key-2.
-      # This is line 2 of the comment for key-2.
-      key-2=value 2 line 1
-            value 2 line 2
-      # This is a comment for key-3.
-      key-3=value 3 line 1
-           =    value 3 line 2 has leading identation.
-           =
-           =    value 3 line 3 is blank. This is line 4.
+   # This is line 1 of the comment for key-2.
+   # This is line 2 of the comment for key-2.
+   key-2=value 2 line 1
+         value 2 line 2
+   # This is a comment for key-3.
+   key-3=value 3 line 1
+        =    value 3 line 2 has leading identation.
+        =
+        =    value 3 line 3 is blank. This is line 4.
 
-      # section-2 is user-ignored.
-      [!section-2]
-      key-4=value 4
-      # ...
+   # section-2 is user-ignored.
+   [!section-2]
+   key-4=value 4
+   # ...
 
-      [section-3]
-      # key-5 is program ignored.
-      !!key-5=value 5
+   [section-3]
+   # key-5 is program ignored.
+   !!key-5=value 5
 
 .. TODO - edit 'rose-lang.py' syntax highlighting to not throw error e.g. for
    'key-2' double-line specification above (with multiple instances in other
@@ -229,13 +229,13 @@ optional configurations ``O1`` and ``O2`` into a new main configuration ``Ct``
 and new optional configurations ``O1t`` and ``O2t`` can be represented like
 this:
 
-   .. code-block:: none
+.. code-block:: none
 
-      C => Ct
-      C + O1 => C1t
-      C + O2 => C2t
-      O1t = C1t - Ct
-      O2t = C2t - Ct
+   C => Ct
+   C + O1 => C1t
+   C + O2 => C2t
+   O1t = C1t - Ct
+   O2t = C2t - Ct
 
 
 Import Configuration

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -96,37 +96,37 @@ We have added the following conventions into our INI format:
 #. Values of settings accept syntax such as $NAME or ${NAME} for environment
    variable substitution.
 
-E.g.
+   .. code-block:: cylc
 
-# This is line 1 of the comment for this file.
-# This is line 2 of the comment for this file.
+      # This is line 1 of the comment for this file.
+      # This is line 2 of the comment for this file.
 
-# This comment will be ignored.
+      # This comment will be ignored.
 
-# This is a comment for section-1.
-[section-1]
-# This is a comment for key-1.
-key-1=value 1
-# This comment will be ignored.
+      # This is a comment for section-1.
+      [section-1]
+      # This is a comment for key-1.
+      key-1=value 1
+      # This comment will be ignored.
 
-# This is line 1 of the comment for key-2.
-# This is line 2 of the comment for key-2.
-key-2=value 2 line 1
-      value 2 line 2
-# This is a comment for key-3.
-key-3=value 3 line 1
-     =    value 3 line 2 has leading identation.
-     =
-     =    value 3 line 3 is blank. This is line 4.
+      # This is line 1 of the comment for key-2.
+      # This is line 2 of the comment for key-2.
+      key-2=value 2 line 1
+            value 2 line 2
+      # This is a comment for key-3.
+      key-3=value 3 line 1
+           =    value 3 line 2 has leading identation.
+           =
+           =    value 3 line 3 is blank. This is line 4.
 
-# section-2 is user-ignored.
-[!section-2]
-key-4=value 4
-# ...
+      # section-2 is user-ignored.
+      [!section-2]
+      key-4=value 4
+      # ...
 
-[section-3]
-# key-5 is program ignored.
-!!key-5=value 5
+      [section-3]
+      # key-5 is program ignored.
+      !!key-5=value 5
 
 In this document, the shorthand SECTION=KEY=VALUE is used to represent a
 KEY=VALUE pair in a [SECTION] of an INI format file.
@@ -151,7 +151,9 @@ configuration keys from environment variables and/or command line options.
 Where multiple $KEY settings are given, the optional configurations are 
 applied in that order - for example, a setting:
 
-opts=ketchup mayonnaise
+   .. code-block:: rose
+
+      opts=ketchup mayonnaise
 
 implies loading the optional configuration rose-app-ketchup.conf and then the
 optional configuration rose-app-mayonnaise.conf, which may override the
@@ -161,7 +163,9 @@ By default, a Rose command will fail if an optional configuration file is
 missing. However, if you put the optional configuration key in brackets,
 then the optional configuration file is allowed to be missing. E.g.:
 
-opts=ketchup (mayonnaise)
+   .. code-block:: rose
+
+      opts=ketchup (mayonnaise)
 
 In the above example, rose-app-mayonnaise.conf can be missing.
 
@@ -193,11 +197,13 @@ The logic for transforming or upgrading a main configuration C with optional
 configurations O1 and O2 into a new main configuration Ct and new optional
 configurations O1t and O2t can be represented like this:
 
-C => Ct
-C + O1 => C1t
-C + O2 => C2t
-O1t = C1t - Ct
-O2t = C2t - Ct
+   .. code-block:: none
+
+      C => Ct
+      C + O1 => C1t
+      C + O2 => C2t
+      O1t = C1t - Ct
+      O2t = C2t - Ct
 
 
 Import Configuration
@@ -219,19 +225,14 @@ allow you to re-define configuration settings at run time using the
 command line. This would add new settings or override any settings defined in
 the main and optional configurations. E.g.:
 
-(shell)$
-(shell)$
-(shell)$
-(shell)$
-(shell)$
-(shell)$
+   .. code-block:: bash
 
-# Set [env]FOO=foo, and [env]BAR=bar
-# (Overriding any original settings of [env]FOO or [env]BAR)
-rose task-run -D '[env]FOO=foo' -D '[env]BAR=bar'
-
-# Switch off [env]BAZ
-rose task-run -D '[env]!BAZ='
+      (shell)$ # Set [env]FOO=foo, and [env]BAR=bar
+      (shell)$ # (Overriding any original settings of [env]FOO or [env]BAR)
+      (shell)$ rose task-run -D '[env]FOO=foo' -D '[env]BAR=bar'
+      (shell)$
+      (shell)$ # Switch off [env]BAZ
+      (shell)$ rose task-run -D '[env]!BAZ='
 
 
 Site and User Configuration
@@ -258,8 +259,10 @@ rosie go. To change the keyboard shortcut of the Find Next action in the
 config editor to F3, put the following lines in your user config file, and
 the setting will apply the next time you run rose config-edit:
 
-[rose-config-edit]
-accel-find-next=F3
+   .. code-block:: rose
+
+      [rose-config-edit]
+      accel-find-next=F3
 
 
 Suite Configuration
@@ -335,8 +338,10 @@ root-dir=LIST
 a glob-like pattern for matching a host name. The DIR should be the root
 directory to install a suite run directory. E.g.:
 
-    root-dir=hpc*=$WORKDIR
-            =*=$DATADIR
+   .. code-block:: rose
+
+      root-dir=hpc*=$WORKDIR
+              =*=$DATADIR
 
     In this example, rose suite-run of a suite with name $NAME will
 create ~/cylc-run/$NAME as a symbolic link to $DATADIR/cylc-run/$NAME/ on
@@ -424,14 +429,16 @@ contain the following:
 
 E.g. The application configuration directory may look like:
 
-./bin/
-./rose-app.conf
-./file/file1
-./file/file2
-./meta/rose-meta.conf
-./opt/rose-app-extra1.conf
-./opt/rose-app-extra2.conf
-...
+   .. code-block:: bash
+
+      ./bin/
+      ./rose-app.conf
+      ./file/file1
+      ./file/file2
+      ./meta/rose-meta.conf
+      ./opt/rose-app-extra1.conf
+      ./opt/rose-app-extra2.conf
+      ...
 
 Application Configuration File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -519,8 +526,10 @@ return code.
 of file paths. If this is not enough, e.g. you want to test for the existence
 of a string in each file, you can specify a file-test to do a grep. E.g.:
 
-    all-files=file1 file2
-    file-test=test -e {} && grep -q 'hello' {}
+   .. code-block:: rose
+
+      all-files=file1 file2
+      file-test=test -e {} && grep -q 'hello' {}
 
     At runtime, any {} pattern in the above would be replaced with the name
 of the file. The above make sure that both file1 and file2 exist and that
@@ -534,17 +543,19 @@ The list is a comma-separated list. The syntax looks like [n*][DURATION],
 where DURATION is an ISO 8601 duration such as PT5S (5 seconds) or
 PT10M (10 minutes), and n is an optional number of times to repeat it. E.g.:
 
-    # Default
-    delays=0
+   .. code-block:: rose
 
-    # Poll 1 minute after the runner begins, repeat every minute 10 times
-    delays=10*PT1M
+      # Default
+      delays=0
 
-    # Poll when runner begins,
-    # repeat every 10 seconds 6 times,
-    # repeat every minute 60 times,
-    # repeat once after 1 hour
-    delays=0,6*PT10S,60*PT1M,PT1H
+      # Poll 1 minute after the runner begins, repeat every minute 10 times
+      delays=10*PT1M
+
+      # Poll when runner begins,
+      # repeat every 10 seconds 6 times,
+      # repeat every minute 60 times,
+      # repeat once after 1 hour
+      delays=0,6*PT10S,60*PT1M,PT1H
 
 Application Configuration File: Built-in Application: fcm_make
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -630,19 +641,23 @@ version control system, or a path to a plain file. The root level schemes
 setting can be used to help the system to do the right thing. The general
 syntax of the value of the root level schemes setting looks like:
 
-schemes=PATTERN-1=SCHEME-1
-       =PATTERN-2=SCHEME-2
+   .. code-block:: rose
+
+      schemes=PATTERN-1=SCHEME-1
+             =PATTERN-2=SCHEME-2
 
 E.g.:
 
-schemes=hpc*:*=rsync
-       =http://host/svn-repos/*=svn
+   .. code-block:: rose
 
-[file:foo.txt]
-source=hpc1:/path/to/foo.txt
+      schemes=hpc*:*=rsync
+             =http://host/svn-repos/*=svn
 
-[file:bar.txt]
-source=http://host/svn-repos/path/to/bar.txt
+      [file:foo.txt]
+      source=hpc1:/path/to/foo.txt
+
+      [file:bar.txt]
+      source=http://host/svn-repos/path/to/bar.txt
 
 In this example, a URI matching the pattern hpc*:* would use the rsync
 scheme to pull the source to the current host, and a URI matching the

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -113,7 +113,7 @@ We have added the following conventions into our INI format:
 #. Values of settings accept syntax such as ``$NAME`` or ``${NAME}`` for
    environment variable substitution.
 
-   .. code-block:: cylc
+   .. code-block:: rose
 
       # This is line 1 of the comment for this file.
       # This is line 2 of the comment for this file.
@@ -144,6 +144,10 @@ We have added the following conventions into our INI format:
       [section-3]
       # key-5 is program ignored.
       !!key-5=value 5
+
+.. TODO - edit 'rose-lang.py' syntax highlighting to not throw error e.g. for
+   'key-2' double-line specification above (with multiple instances in other
+   User Guide files).
 
 In this document, the shorthand ``SECTION=KEY=VALUE`` is used to represent a
 ``KEY=VALUE`` pair in a ``[SECTION]`` of an INI format file.

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -108,8 +108,11 @@ We have added the following conventions into our INI format:
    settings to the earlier one. If the same key in the same section is
    declared twice, the later value will override the earlier one. This logic
    applies to the state of a setting as well.
-#. Once the file is parsed, declaration ordering is insignificant. N.B. Do
-   not assume order of environment variables.
+#. Once the file is parsed, declaration ordering is insignificant.
+
+   .. note::
+      Do not assume order of environment variables.
+
 #. Values of settings accept syntax such as ``$NAME`` or ``${NAME}`` for
    environment variable substitution.
 
@@ -151,8 +154,9 @@ E.g.
    'key-2' double-line specification above (with multiple instances in other
    User Guide files).
 
-In this document, the shorthand ``SECTION=KEY=VALUE`` is used to represent a
-``KEY=VALUE`` pair in a ``[SECTION]`` of an INI format file.
+.. note::
+   In this document, the shorthand ``SECTION=KEY=VALUE`` is used to represent a
+   ``KEY=VALUE`` pair in a ``[SECTION]`` of an INI format file.
 
 .. _opt-config:
 
@@ -200,11 +204,13 @@ optional configurations to be selected at run time using:
 #. The ``ROSE_APP_OPT_CONF_KEYS`` Environment variables.
 #. The command line options ``--opt-conf-key=KEY`` or ``-O KEY``.
 
-See reference of individual commands for detail.
+.. tip::
+   See reference of individual commands for detail.
 
-Note that by default optional configurations must exist else an error will
-be raised. To specify an optional configuration which may be missing write
-the name of the configuration inside parenthesis (e.g. ``(foo)``).
+.. note::
+   By default optional configurations must exist else an error will
+   be raised. To specify an optional configuration which may be missing write
+   the name of the configuration inside parenthesis (e.g. ``(foo)``).
 
 Optional Configurations and Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,7 +245,8 @@ A root level ``import=PATH1 PATH2...`` setting in the main configuration will
 tell Rose utilities to search for configurations at ``PATH1``, ``PATH2`` (and
 so on) and inherit configuration and files from them if found.
 
-At the moment, use of this is only encouraged for configuration metadata.
+.. tip::
+   At the moment, use of this is only encouraged for configuration metadata.
 
 
 Re-define Configuration at Run Time
@@ -278,10 +285,11 @@ the ``rose`` command, and they search for the user configuration at
 ``$HOME/.metomi/rose.conf`` where ``$HOME`` is the home directory of the
 current user.
 
-*Allowed settings in the site and user configuration files will be documented
-in a future version of this document. In the mean time, the settings are 
-documented as comments in the* ``etc/rose.conf.example`` *file of each
-distribution of Rose.*
+.. note::
+   Allowed settings in the site and user configuration files will be
+   documented in a future version of this document. In the mean time, the
+   settings are documented as comments in the ``etc/rose.conf.example``
+   file of each distribution of Rose.
 
 You can also override many internal constants of the ``rose config edit`` and
 ``rosie go``. To change the keyboard shortcut of the ``Find Next`` action in
@@ -403,10 +411,16 @@ It may have the following top level (no section) options:
   created.
 
 ``root-dir-share=LIST``
-  Deprecated. Same as ``root-dir{share}=LIST``.
+  .. warning::
+     Deprecated.
+
+  Same as ``root-dir{share}=LIST``.
 
 ``root-dir-work=LIST``
-  Deprecated. Same as ``root-dir{work}=LIST``.
+  .. warning::
+     Deprecated.
+
+  Same as ``root-dir{work}=LIST``.
 
 .. _suite-config-suite-info:
 
@@ -468,14 +482,16 @@ contain the following:
 
   Files in this directory are copied to the working directory in run time.
 
-  Note: If there is a clash between a ``[file:*]`` section and a file under
-  ``file/``, the setting in the ``[file:*]`` section takes precedence. E.g.
-  Suppose we have a file ``file/hello.txt``. In the absence of
-  ``[file:hello.txt]``, it will copy ``file/hello.txt`` to ``$PWD/hello.txt``
-  in run time. However, if we have a ``[file:hello.txt]`` section and a
-  ``source=SOURCE`` setting, then it will install
-  the file from ``SOURCE`` instead. If we have ``[!file:hello.txt]``, then
-  the file will not be installed at all.
+  .. note::
+     If there is a clash between a ``[file:*]`` section and a file under
+     ``file/``, the setting in the ``[file:*]`` section takes precedence.
+     E.g. Suppose we have a file ``file/hello.txt``. In the absence of
+     ``[file:hello.txt]``, it will copy ``file/hello.txt`` to
+     ``$PWD/hello.txt`` in run time. However, if we have a
+     ``[file:hello.txt]`` section and a ``source=SOURCE`` setting, then it
+     will install the file from ``SOURCE`` instead. If we have
+     ``[!file:hello.txt]``, then the file will not be installed at all.
+
 * ``bin/`` directory for e.g. scripts and executables used by the application
   at run time. If a ``bin/`` exists in the application configuration, it will 
   prepended to the ``PATH`` environment variable at run time.
@@ -533,17 +549,24 @@ keys can be:
   The usual ``$NAME`` or ``${NAME}`` syntax can be used in values to reference
   environment variables that are already defined when the application runner
   is invoked. However, it is unsafe to reference other environment variables
-  defined in this section. Note: ``UNDEF`` is a special variable that is
-  always undefined at run time. Reference to it will cause a failure at run
-  time. It can be used to indicate that a value must be overridden at run
-  time. If the value of an environment variable setting begins with a tilde
+  defined in this section.
+
+  .. note::
+     ``UNDEF`` is a special variable that is always undefined at run time.
+     Reference to it will cause a failure at run time. It can be used to
+     indicate that a value must be overridden at run time.
+  
+  If the value of an environment variable setting begins with a tilde
   ``~``, all of the characters preceding the 1st slash ``/`` are considered a
   *tilde-prefix*. Where possible, a tilde-prefix is replaced with the home
   directory associated with the specified login name at run time.
 
 ``[etc]``
-  Specify misc. settings. Currently, only UM defs for science sections are
-  thought to require this section.
+  Specify misc. settings.
+
+  .. tip::
+     Currently, only UM defs for science sections are
+     thought to require this section.
 
 ``[file:NAME]``
   Specify a file/directory to be generated by the application runner at
@@ -595,18 +618,21 @@ keys can be:
     (zero) return code.
 
   Normally, the ``all-files`` and ``any-files`` tests both test for the
-  existence of file paths. If this is not enough, e.g. you want to test for
-  the existence of a string in each file, you can specify a ``file-test`` to
-  do a ``grep``. E.g.:
+  existence of file paths.
+  
+  .. tip::
+     If this is not enough, e.g. you want to test for the existence of a
+     string in each file, you can specify a ``file-test`` to
+     do a ``grep``. E.g.:
 
-  .. code-block:: rose
+     .. code-block:: rose
 
-     all-files=file1 file2
-     file-test=test -e {} && grep -q 'hello' {}
+        all-files=file1 file2
+        file-test=test -e {} && grep -q 'hello' {}
 
-  At runtime, any ``{}`` pattern in the above would be replaced with the name
-  of the file. The above make sure that both ``file1`` and ``file2`` exist
-  and that they both contain the string ``hello``.
+     At runtime, any ``{}`` pattern in the above would be replaced with the
+     name of the file. The above make sure that both ``file1`` and ``file2``
+     exist and that they both contain the string ``hello``.
 
   The above tests will only be performed once when the application runner
   starts. If a list of ``delays`` are added, the tests will be performed a
@@ -684,18 +710,22 @@ A ``[file:TARGET]`` section may have the following settings:
   or be given sufficient information for the system to determine its scheme,
   e.g. via the root level ``schemes`` setting described below.
 
-  Normally, a source that does not exist would trigger an error in run time.
-  However, it may be useful to have an optional source for a file sometimes.
-  In which case, the syntax ``source=(SOURCE)`` can be used to specify an
-  optional source. E.g. ``source=namelist:foo (namelist:bar)`` would allow
-  ``namelist:bar`` to be missing or ignored without an error.
+  .. tip::
+     Normally, a source that does not exist would trigger an error in run
+     time. However, it may be useful to have an optional source for a file
+     sometimes. In which case, the syntax ``source=(SOURCE)`` can be used to
+     specify an optional source. E.g. ``source=namelist:foo (namelist:bar)``
+     would allow ``namelist:bar`` to be missing or ignored without an error.
 
 ``checksum``
   The expected MD5 checksum of the target. If specified, the file
   generation will fail if the actual checksum of the target does not match
   with this setting. This setting is only meaningful if ``TARGET`` is a
-  regular file or a symbolic link to a regular file. N.B. An empty value for
-  checksum tells the system to report the target checksum in verbose mode.
+  regular file or a symbolic link to a regular file.
+
+  .. note::
+     An empty value for checksum tells the system to report the target
+     checksum in verbose mode.
 
 ``mode``
   ``auto`` (default), ``mkdir``, ``symlink`` or ``symlink+``.
@@ -716,14 +746,18 @@ A ``[file:TARGET]`` section may have the following settings:
     Target is a directory.
 
   ``mode=symlink,source=SOURCE``
-    Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
-    ``SOURCE`` must be a single source. ``SOURCE`` does not have to exist when
-    the symbolic link is created.
+    Target is created as a symlink of an FS ``SOURCE``.
+
+    .. note::
+       In this mode, ``SOURCE`` must be a single source. ``SOURCE`` does
+       not have to exist when the symbolic link is created.
 
   ``mode=symlink+,source=SOURCE``
-    Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
-    ``SOURCE`` must be a single source. ``SOURCE`` must exist when the symbolic
-    link is created.
+    Target is created as a symlink of an FS ``SOURCE``.
+
+    .. note::
+       In this mode, ``SOURCE`` must be a single source. ``SOURCE`` must
+       exist when the symbolic link is created.
 
 The root level ``schemes`` setting: While the system would attempt to
 automatically detect the scheme of a source, the name of the source can
@@ -755,8 +789,9 @@ In this example, a URI matching the pattern ``hpc*:*`` would use the
 the pattern ``http://host/svn-repos/*`` would use the ``svn`` scheme. For all
 other URIs, the system will try to make an intelligent guess.
 
-The system will always match a URI in the order as specified by the setting
-to avoid ambiguity.
+.. tip::
+   The system will always match a URI in the order as specified by the
+   setting to avoid ambiguity.
 
 The system has built-in support for the following schemes:
 
@@ -776,8 +811,10 @@ The system has built-in support for the following schemes:
 ``rsync``
   This scheme is useful for pulling a file or directory from a remote
   host using ``rsync`` via ``ssh``. A URI should have the form ``HOST:PATH``.
-  (Note: If required, you can use the `User`_ setting in ``~/.ssh/config`` to
-  specify the user ID for logging into ``HOST``.)
+  
+  .. note::
+     If required, you can use the `User`_ setting in ``~/.ssh/config`` to
+     specify the user ID for logging into ``HOST``.
 
 The application launcher will use the following logic to determine the
 root directory to install file targets with a relative path:

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -49,6 +49,7 @@ We have added the following conventions into our INI format:
    trailing comments. Comments are normally ignored when a configuration file
    is loaded. However, some comments are loaded if the following conditions
    are met:
+
    * Comment lines at the beginning of a configuration file up to but not
      including the 1st blank line or the 1st setting are comment lines
      associated with the file. They will re-appear at the top of the file
@@ -58,6 +59,7 @@ We have added the following conventions into our INI format:
      comments associated with the next setting. The comment lines associated
      with a setting will re-appear before the setting when the file is
      re-dumped.
+
 #. Only the equal sign = is used to delimit a key-value pair - because the 
    colon : may be used in keys of namelist declarations.
 #. A key-value pair declaration does not have to live under a section 
@@ -69,20 +71,24 @@ We have added the following conventions into our INI format:
    lowercase values should be used.
 #. When writing namelist inputs, keys should be lowercase.
 #. Declarations start at column 1. Continuations start at column >1.
+
    * Each line is stripped of leading and trailing spaces.
    * A newline \n character is prefixed to each continuation line.
    * If a continuation line has a leading equal sign = character, it is
      stripped from the line. This is useful for retaining leading white 
      spaces in a continuation line.
+
 #. A single exclamation ! or a double exclamation !! in front of a section
    (i.e. [!SECTION]) or key=value pair (i.e. !key=value) denotes an ignored
    setting.
+
    * E.g. It will be ignored in run time but may be used by other Rose
      utilities.
    * A single exclamation denotes a user-ignored setting.
    * A double exclamation denotes a program-ignored setting. E.g. rose
      config-edit may use a double exclamation to switch off a setting
      according to the setting metadata.
+
 #. The open square bracket ([) and close square bracket (]) characters
    cannot be used within a section declaration. E.g.
    [[hello], [hello]], [hello [world] and beyond] should all be errors on
@@ -300,70 +306,77 @@ information on how to install the suite. It may have the following sections
 and root level options:
 
 [env]
-    Specify the environment variables to export to the suite daemon. The
-usual $NAME or ${NAME} syntax can be used in values to reference environment
-variables that are already defined before the suite runner is invoked.
-However, it is unsafe to reference other environment variables defined in
-this section. If the value of an environment variable setting begins with a
-tilde ~, all of the characters preceding the 1st slash / are considered a
-tilde-prefix. Where possible, a tilde-prefix is replaced with the home
-directory associated with the specified login name at run time. There are 2
-special environment variables which can be specified in this section:
+  Specify the environment variables to export to the suite daemon. The
+  usual $NAME or ${NAME} syntax can be used in values to reference environment
+  variables that are already defined before the suite runner is invoked.
+  However, it is unsafe to reference other environment variables defined in
+  this section. If the value of an environment variable setting begins with a
+  tilde ~, all of the characters preceding the 1st slash / are considered a
+  tilde-prefix. Where possible, a tilde-prefix is replaced with the home
+  directory associated with the specified login name at run time. There are 2
+  special environment variables which can be specified in this section:
 
-* ROSE_VERSION: If specified, the version of Rose that starts the suite
-  run must match the specified version.
-* CYLC_VERSION: If specified for a cylc suite, the Rose suite runner
-  will attempt to use this version of cylc.
+  * ROSE_VERSION: If specified, the version of Rose that starts the suite
+    run must match the specified version.
+  * CYLC_VERSION: If specified for a cylc suite, the Rose suite runner
+    will attempt to use this version of cylc.
 
 [jinja2:suite.rc]
-    For a cylc suite, if jinja2 assignments are required for suite.rc, they
-may be defined as key=value pairs in the [jinja2:suite.rc] section. The
-assignments will be inserted after the #!jinja2 line of the installed
-suite.rc file.
-[file:NAME]
-    Specify a file/directory to be installed. NAME should be a path
-relative to the run time $PWD.
+  For a cylc suite, if jinja2 assignments are required for suite.rc, they
+  may be defined as key=value pairs in the [jinja2:suite.rc] section. The
+  assignments will be inserted after the #!jinja2 line of the installed
+  suite.rc file.
 
-* E.g. file:app/APP=source=LOCATION.
-* See Appendix: File Creation Mode.
+[file:NAME]
+  Specify a file/directory to be installed. NAME should be a path
+  relative to the run time $PWD.
+
+  * E.g. file:app/APP=source=LOCATION.
+  * See Appendix: File Creation Mode.
 
 It may have the following top level (no section) options:
 
 meta
-    Specify the configuration metadata for the suite. The section may be
-used by various Rose utilities, such as the config editor GUI. It can be
-used to specify the suite type.
+  Specify the configuration metadata for the suite. The section may be
+  used by various Rose utilities, such as the config editor GUI. It can be
+  used to specify the suite type.
+
 root-dir=LIST
-    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be
-a glob-like pattern for matching a host name. The DIR should be the root
-directory to install a suite run directory. E.g.:
+  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be
+  a glob-like pattern for matching a host name. The DIR should be the root
+  directory to install a suite run directory. E.g.:
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      root-dir=hpc*=$WORKDIR
-              =*=$DATADIR
+     root-dir=hpc*=$WORKDIR
+             =*=$DATADIR
 
-    In this example, rose suite-run of a suite with name $NAME will
-create ~/cylc-run/$NAME as a symbolic link to $DATADIR/cylc-run/$NAME/ on
-any machine, except those with their hostnames matching hpc*. In which
-case, it will create ~/cylc-run/$NAME as a symbolic link to
-$WORKDIR/cylc-run/$NAME/.
+  In this example, rose suite-run of a suite with name $NAME will
+  create ~/cylc-run/$NAME as a symbolic link to $DATADIR/cylc-run/$NAME/ on
+  any machine, except those with their hostnames matching hpc*. In which
+  case, it will create ~/cylc-run/$NAME as a symbolic link to
+  $WORKDIR/cylc-run/$NAME/.
+
 root-dir{share}=LIST
-    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-glob-like pattern for matching a host name. The DIR should be the root
-directory where the suite's share/ directory should be created.
+  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+  glob-like pattern for matching a host name. The DIR should be the root
+  directory where the suite's share/ directory should be created.
+
 root-dir{share/cycle}=LIST
-    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-glob-like pattern for matching a host name. The DIR should be the root
-directory where the suite's share/cycle/ directory should be created.
+  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+  glob-like pattern for matching a host name. The DIR should be the root
+  directory where the suite's share/cycle/ directory should be created.
+
 root-dir{work}=LIST
-    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-glob-like pattern for matching a host name. The DIR should be the root
-directory where the suite's work/ directory for tasks should be created.
+  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+  glob-like pattern for matching a host name. The DIR should be the root
+  directory where the suite's work/ directory for tasks should be created.
+
 root-dir-share=LIST
-    Deprecated. Same as root-dir{share}=LIST.
+  Deprecated. Same as root-dir{share}=LIST.
+
 root-dir-work=LIST
-    Deprecated. Same as root-dir{work}=LIST.
+  Deprecated. Same as root-dir{work}=LIST.
 
 Suite Configuration: Suite Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,22 +389,27 @@ with -list, the value is expected to be a space-delimited list. The
 following keys are known to have special meanings:
 
 owner
-    Specify the user ID of the owner of the suite. The owner has full commit
-access to the suite. Only the owner can delete the suite, pass the suite's
-ownership to someone else or change the access-list.
+  Specify the user ID of the owner of the suite. The owner has full commit
+  access to the suite. Only the owner can delete the suite, pass the suite's
+  ownership to someone else or change the access-list.
+
 project
-    Specify the name of the project associated with the suite.
+  Specify the name of the project associated with the suite.
+
 title
-    Specify a short title of the suite.
+  Specify a short title of the suite.
+
 access-list
-    Specify a list of users with commit access to trunk of the suite. A * in
-the list means that anyone can commit to the trunk of the suite. Setting
-this blank or omitting the setting means that nobody apart from the owner
-can commit to the trunk. Only the suite owner can change the access list.
+  Specify a list of users with commit access to trunk of the suite. A * in
+  the list means that anyone can commit to the trunk of the suite. Setting
+  this blank or omitting the setting means that nobody apart from the owner
+  can commit to the trunk. Only the suite owner can change the access list.
+
 description
-    Specify a long description of the suite.
+  Specify a long description of the suite.
+
 sub-project
-    Specify a sub-division of project, if applicable.
+  Specify a sub-division of project, if applicable.
 
 
 Application Configuration
@@ -402,12 +420,14 @@ contain the following:
 
 * rose-app.conf: a compulsory configuration file in the modified INI format.
   See below for detail. It contains the following information:
+
   * the command(s) to run.
   * the metadata type for the application.
   * the list of environment variables.
   * other configurations that can be represented in un-ordered key=value
     pairs, e.g. Fortran namelists.
 * file/ directory: other input files, e.g.:
+
   * FCM configuration files (requires ordering of key=value pairs).
   * STASH files.
   * other configuration files that require more than section=key=value.
@@ -449,113 +469,122 @@ keys=values without a section, at the top level. The sections and keys can
 be:
 
 file-install-root
-    Root level setting. Specify the root directory to install file targets
-that are specified with a relative path.
-meta
-    Root level setting. Specify the configuration metadata for the application. This is ignored by the application runner, but may be used by other
-Rose utilities, such as the config editor GUI. It can be used to specify
-the application type.
-mode
-    Root level setting. Specify the name of a builtin application, instead of
-running a command specified in the [command] section. See also Running
-Tasks > rose task-run > Built-in Applications Selection
-[command]
-    Specify the command(s) to run. The default key can be used to define the
-default command to run. Other keys can be used to define alternate commands,
-which can be selected at run time.
-[env]
-    Specify input environment variables to the command, in KEY=VALUE pairs.
-The usual $NAME or ${NAME} syntax can be used in values to reference
-environment variables that are already defined when the application runner
-is invoked. However, it is unsafe to reference other environment variables
-defined in this section. Note: UNDEF is a special variable that is always
-undefined at run time. Reference to it will cause a failure at run time. It
-can be used to indicate that a value must be overridden at run time. If the
-value of an environment variable setting begins with a tilde ~, all of the
-characters preceding the 1st slash / are considered a tilde-prefix. Where
-possible, a tilde-prefix is replaced with the home directory associated with
-the specified login name at run time.
-[etc]
-    Specify misc. settings. Currently, only UM defs for science sections are
-thought to require this section.
-[file:NAME]
-    Specify a file/directory to be generated by the application runner at
-run time. NAME should be a path relative to the run time $PWD, or STDIN.
+  Root level setting. Specify the root directory to install file targets
+  that are specified with a relative path.
 
-* E.g. file:app/APP=source=LOCATION.
-* See Appendix: File Creation Mode.
+meta
+  Root level setting. Specify the configuration metadata for the application.
+  This is ignored by the application runner, but may be used by other
+  Rose utilities, such as the config editor GUI. It can be used to specify
+  the application type.
+
+mode
+  Root level setting. Specify the name of a builtin application, instead of
+  running a command specified in the [command] section. See also Running
+  Tasks > rose task-run > Built-in Applications Selection
+
+[command]
+  Specify the command(s) to run. The default key can be used to define the
+  default command to run. Other keys can be used to define alternate commands,
+  which can be selected at run time.
+
+[env]
+  Specify input environment variables to the command, in KEY=VALUE pairs.
+  The usual $NAME or ${NAME} syntax can be used in values to reference
+  environment variables that are already defined when the application runner
+  is invoked. However, it is unsafe to reference other environment variables
+  defined in this section. Note: UNDEF is a special variable that is always
+  undefined at run time. Reference to it will cause a failure at run time. It
+  can be used to indicate that a value must be overridden at run time. If the
+  value of an environment variable setting begins with a tilde ~, all of the
+  characters preceding the 1st slash / are considered a tilde-prefix. Where
+  possible, a tilde-prefix is replaced with the home directory associated with
+  the specified login name at run time.
+
+[etc]
+  Specify misc. settings. Currently, only UM defs for science sections are
+  thought to require this section.
+
+[file:NAME]
+  Specify a file/directory to be generated by the application runner at
+  run time. NAME should be a path relative to the run time $PWD, or STDIN.
+
+  * E.g. file:app/APP=source=LOCATION.
+  * See Appendix: File Creation Mode.
 
 [namelist:NAME]
-    Specify a namelist with the group name called NAME, which can be
-referred to by a source setting of a file. Each setting in a namelist:NAME
-section is a KEY=VALUE pair exactly like a normal Fortran namelist, but
-without the trailing comma.
-[namelist:NAME(SORT-INDEX)]
-    Same as [namelist:NAME] but:
+  Specify a namelist with the group name called NAME, which can be
+  referred to by a source setting of a file. Each setting in a namelist:NAME
+  section is a KEY=VALUE pair exactly like a normal Fortran namelist, but
+  without the trailing comma.
 
-* It allows the source setting of a file to refer to all
-[namelist:NAME(SORT-INDEX)] as namelist:NAME(:), and the namelist groups
-will be sorted alphanumerically by the SORT-INDEX.
-* It allows different namelist files to have namelists with the same group
-name. These will all inherit the same group configuration metadata
-(from [namelist:NAME]).
+[namelist:NAME(SORT-INDEX)]
+  Same as [namelist:NAME] but:
+
+  * It allows the source setting of a file to refer to all
+    [namelist:NAME(SORT-INDEX)] as namelist:NAME(:), and the namelist groups
+    will be sorted alphanumerically by the SORT-INDEX.
+  * It allows different namelist files to have namelists with the same group
+    name. These will all inherit the same group configuration metadata
+    (from [namelist:NAME]).
 
 [namelist:NAME{CATEGORY}] or [namelist:NAME{CATEGORY}(SORT-INDEX)]
-    Same as [namelist:NAME(SORT-INDEX)] but:
+  Same as [namelist:NAME(SORT-INDEX)] but:
 
-* An alternate way for grouping namelists. This allows the same namelist
-to have different usage and configuration metadata according to its
-category. Namelists will inherit configuration metadata from their basic
-group [namelist:NAME] as well as from their specific category
-[namelist:NAME{CATEGORY}].
+  * An alternate way for grouping namelists. This allows the same namelist
+    to have different usage and configuration metadata according to its
+    category. Namelists will inherit configuration metadata from their basic
+    group [namelist:NAME] as well as from their specific category
+    [namelist:NAME{CATEGORY}].
 
 [poll]
-    Specify prerequisites to poll for before running the actual application.
-3 types of tests can be performed:
+  Specify prerequisites to poll for before running the actual application.
+  3 types of tests can be performed:
 
-    all-files: A list of space delimited list of file paths. This test passes
-only if all file paths in the list exist.
+  all-files: A list of space delimited list of file paths. This test passes
+  only if all file paths in the list exist.
 
-    any-files: A list of space delimited list of file paths. This test passes
-if any file path in the list exists.
+  any-files: A list of space delimited list of file paths. This test passes
+  if any file path in the list exists.
 
-    test: A shell command. This test passes if the command returns a 0 (zero)
-return code.
+  test: A shell command. This test passes if the command returns a 0 (zero)
+  return code.
 
-    Normally, the all-files and any-files tests both test for the existence
-of file paths. If this is not enough, e.g. you want to test for the existence
-of a string in each file, you can specify a file-test to do a grep. E.g.:
+  Normally, the all-files and any-files tests both test for the existence
+  of file paths. If this is not enough, e.g. you want to test for the existence
+  of a string in each file, you can specify a file-test to do a grep. E.g.:
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      all-files=file1 file2
-      file-test=test -e {} && grep -q 'hello' {}
+     all-files=file1 file2
+     file-test=test -e {} && grep -q 'hello' {}
 
-    At runtime, any {} pattern in the above would be replaced with the name
-of the file. The above make sure that both file1 and file2 exist and that
-they both contain the string hello.
+  At runtime, any {} pattern in the above would be replaced with the name
+  of the file. The above make sure that both file1 and file2 exist and that
+  they both contain the string hello.
 
-    The above tests will only be performed once when the application runner
-starts. If a list of delays are added, the tests will be performed a number
-of times with delays between them. If the prerequisites are still not met
-after the number of delays, the application runner will fail with a time out.
-The list is a comma-separated list. The syntax looks like [n*][DURATION],
-where DURATION is an ISO 8601 duration such as PT5S (5 seconds) or
-PT10M (10 minutes), and n is an optional number of times to repeat it. E.g.:
+  The above tests will only be performed once when the application runner
+  starts. If a list of delays are added, the tests will be performed a number
+  of times with delays between them. If the prerequisites are still not met
+  after the number of delays, the application runner will fail with a time
+  out. The list is a comma-separated list. The syntax looks like
+  [n*][DURATION], where DURATION is an ISO 8601 duration such as PT5S
+  (5 seconds) or PT10M (10 minutes), and n is an optional number of times
+  to repeat it. E.g.:
 
-   .. code-block:: rose
+  .. code-block:: rose
 
-      # Default
-      delays=0
+     # Default
+     delays=0
 
-      # Poll 1 minute after the runner begins, repeat every minute 10 times
-      delays=10*PT1M
+     # Poll 1 minute after the runner begins, repeat every minute 10 times
+     delays=10*PT1M
 
-      # Poll when runner begins,
-      # repeat every 10 seconds 6 times,
-      # repeat every minute 60 times,
-      # repeat once after 1 hour
-      delays=0,6*PT10S,60*PT1M,PT1H
+     # Poll when runner begins,
+     # repeat every 10 seconds 6 times,
+     # repeat every minute 60 times,
+     # repeat once after 1 hour
+     delays=0,6*PT10S,60*PT1M,PT1H
 
 Application Configuration File: Built-in Application: fcm_make
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -591,48 +620,55 @@ Appendix: File Creation Mode
 A [file:TARGET] section may have the following settings:
 
 source
-    A space delimited list of sources for generating this file. A source can
-be the path to a regular file or directory in the file system (globbing is
-also supported - e.g. using "*.conf" to mean all .conf files), or it may be
-a URI to a resource. If a source is a URI, it may point to a section with a
-supported scheme in the current configuration, e.g. a namelist:NAME section.
-Otherwise the URI must be in a supported scheme or be given sufficient
-information for the system to determine its scheme, e.g. via the root level
-schemes setting described below.
+  A space delimited list of sources for generating this file. A source can
+  be the path to a regular file or directory in the file system (globbing is
+  also supported - e.g. using "\*.conf" to mean all .conf files), or it may be
+  a URI to a resource. If a source is a URI, it may point to a section with a
+  supported scheme in the current configuration, e.g. a namelist:NAME section.
+  Otherwise the URI must be in a supported scheme or be given sufficient
+  information for the system to determine its scheme, e.g. via the root level
+  schemes setting described below.
 
-    Normally, a source that does not exist would trigger an error in run
-time. However, it may be useful to have an optional source for a file
-sometimes. In which case, the syntax source=(SOURCE) can be used to specify
-an optional source. E.g. source=namelist:foo (namelist:bar) would allow
-namelist:bar to be missing or ignored without an error.
+  Normally, a source that does not exist would trigger an error in run
+  time. However, it may be useful to have an optional source for a file
+  sometimes. In which case, the syntax source=(SOURCE) can be used to specify
+  an optional source. E.g. source=namelist:foo (namelist:bar) would allow
+  namelist:bar to be missing or ignored without an error.
+
 checksum
-    The expected MD5 checksum of the target. If specified, the file
-generation will fail if the actual checksum of the target does not match
-with this setting. This setting is only meaningful if TARGET is a regular
-file or a symbolic link to a regular file. N.B. An empty value for
-checksum tells the system to report the target checksum in verbose mode.
+  The expected MD5 checksum of the target. If specified, the file
+  generation will fail if the actual checksum of the target does not match
+  with this setting. This setting is only meaningful if TARGET is a regular
+  file or a symbolic link to a regular file. N.B. An empty value for
+  checksum tells the system to report the target checksum in verbose mode.
+
 mode
-    auto (default), mkdir, symlink or symlink+. See below.
+  auto (default), mkdir, symlink or symlink+. See below.
 
 The following is a list of all the supported usages:
 
 mode=auto,source=
-    Target is an empty file.
+  Target is an empty file.
+
 mode=auto,source=SOURCE
-    Target is a copy of SOURCE.
+  Target is a copy of SOURCE.
+
 mode=auto,source=SOURCE-LIST
-    Target is created by concatenating the contents of SOURCE-LIST. The
-sources should either be all files or all directories.
+  Target is created by concatenating the contents of SOURCE-LIST. The
+  sources should either be all files or all directories.
+
 mode=mkdir
-    Target is a directory.
+  Target is a directory.
+
 mode=symlink,source=SOURCE
-    Target is created as a symlink of an FS SOURCE. N.B. In this mode,
-SOURCE must be a single source. SOURCE does not have to exist when the
-symbolic link is created.
+  Target is created as a symlink of an FS SOURCE. N.B. In this mode,
+  SOURCE must be a single source. SOURCE does not have to exist when the
+  symbolic link is created.
+
 mode=symlink+,source=SOURCE
-    Target is created as a symlink of an FS SOURCE. N.B. In this mode,
-SOURCE must be a single source. SOURCE must exist when the symbolic link
-is created.
+  Target is created as a symlink of an FS SOURCE. N.B. In this mode,
+  SOURCE must be a single source. SOURCE must exist when the symbolic link
+  is created.
 
 The root level schemes setting: While the system would attempt to
 automatically detect the scheme of a source, the name of the source can
@@ -650,8 +686,8 @@ E.g.:
 
    .. code-block:: rose
 
-      schemes=hpc*:*=rsync
-             =http://host/svn-repos/*=svn
+      schemes=hpc\*:\*=rsync
+             =http://host/svn-repos/\*=svn
 
       [file:foo.txt]
       source=hpc1:/path/to/foo.txt
@@ -659,9 +695,9 @@ E.g.:
       [file:bar.txt]
       source=http://host/svn-repos/path/to/bar.txt
 
-In this example, a URI matching the pattern hpc*:* would use the rsync
+In this example, a URI matching the pattern hpc\*:\* would use the rsync
 scheme to pull the source to the current host, and a URI matching the
-pattern http://host/svn-repos/* would use the svn scheme. For all other
+pattern http://host/svn-repos/\* would use the svn scheme. For all other
 URIs, the system will try to make an intelligent guess.
 
 The system will always match a URI in the order as specified by the setting
@@ -670,29 +706,32 @@ to avoid ambiguity.
 The system has built-in support for the following schemes:
 
 fs
-    The file system scheme. If a URI looks like an existing path in the
-file system, this scheme will be used.
+  The file system scheme. If a URI looks like an existing path in the
+  file system, this scheme will be used.
+
 namelist
-    The namelist scheme. Refer to namelist:NAME sections in the configuration
-file.
+  The namelist scheme. Refer to namelist:NAME sections in the configuration
+  file.
+
 svn
-    The Subversion scheme. The location is a Subversion URL or an FCM
-location keyword. A URI with these schemes svn, svn+ssh and fcm are
-automatically recognised.
+  The Subversion scheme. The location is a Subversion URL or an FCM
+  location keyword. A URI with these schemes svn, svn+ssh and fcm are
+  automatically recognised.
+
 rsync
-    This scheme is useful for pulling a file or directory from a remote
-host using rsync via ssh. A URI should have the form HOST:PATH. (Note: If
-required, you can use the User setting in ~/.ssh/config to specify the user
-ID for logging into HOST.)
+  This scheme is useful for pulling a file or directory from a remote
+  host using rsync via ssh. A URI should have the form HOST:PATH. (Note: If
+  required, you can use the User setting in ~/.ssh/config to specify the user
+  ID for logging into HOST.)
 
 The application launcher will use the following logic to determine the
 root directory to install file targets with a relative path:
 
-    If the setting file-install-root=PATH is specified (at the root level)
-in the application configuration file, its value will be used.
-    If the environment variable ROSE_FILE_INSTALL_ROOT is specified, its
-value will be used.
-    Otherwise, the working directory of the task will be used.
+#. If the setting file-install-root=PATH is specified (at the root level)
+   in the application configuration file, its value will be used.
+#. If the environment variable ROSE_FILE_INSTALL_ROOT is specified, its
+   value will be used.
+#. Otherwise, the working directory of the task will be used.
 
 
 Appendix: rose-ana configuration format

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -179,9 +179,9 @@ configuration keys from environment variables and/or command line options.
 Where multiple ``$KEY`` settings are given, the optional configurations are 
 applied in that order - for example, a setting:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      opts=ketchup mayonnaise
+   opts=ketchup mayonnaise
 
 implies loading the optional configuration ``rose-app-ketchup.conf`` and then
 the optional configuration ``rose-app-mayonnaise.conf``, which may override
@@ -191,9 +191,9 @@ By default, a Rose command will fail if an optional configuration file is
 missing. However, if you put the optional configuration key in brackets,
 then the optional configuration file is allowed to be missing. E.g.:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      opts=ketchup (mayonnaise)
+   opts=ketchup (mayonnaise)
 
 In the above example, ``rose-app-mayonnaise.conf`` can be missing.
 
@@ -259,14 +259,14 @@ to re-define configuration settings at run time using the
 the command line. This would add new settings or override any settings
 defined in the main and optional configurations. E.g.:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      (shell)$ # Set [env]FOO=foo, and [env]BAR=bar
-      (shell)$ # (Overriding any original settings of [env]FOO or [env]BAR)
-      (shell)$ rose task-run -D '[env]FOO=foo' -D '[env]BAR=bar'
-      (shell)$
-      (shell)$ # Switch off [env]BAZ
-      (shell)$ rose task-run -D '[env]!BAZ='
+   # Set [env]FOO=foo, and [env]BAR=bar
+   # (Overriding any original settings of [env]FOO or [env]BAR)
+   rose task-run -D '[env]FOO=foo' -D '[env]BAR=bar'
+
+   # Switch off [env]BAZ
+   rose task-run -D '[env]!BAZ='
 
 
 .. _site-n-user-conf:
@@ -296,10 +296,10 @@ You can also override many internal constants of the ``rose config edit`` and
 the config editor to ``F3``, put the following lines in your user config file,
 and the setting will apply the next time you run ``rose config-edit``:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      [rose-config-edit]
-      accel-find-next=F3
+   [rose-config-edit]
+   accel-find-next=F3
 
 
 Suite Configuration
@@ -766,23 +766,23 @@ version control system, or a path to a plain file. The root level ``schemes``
 setting can be used to help the system to do the right thing. The general
 syntax of the value of the root level ``schemes`` setting looks like:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      schemes=PATTERN-1=SCHEME-1
-             =PATTERN-2=SCHEME-2
+   schemes=PATTERN-1=SCHEME-1
+          =PATTERN-2=SCHEME-2
 
 E.g.:
 
-   .. code-block:: rose
+.. code-block:: rose
 
-      schemes=hpc*:*=rsync
-             =http://host/svn-repos/*=svn
+   schemes=hpc*:*=rsync
+          =http://host/svn-repos/*=svn
 
-      [file:foo.txt]
-      source=hpc1:/path/to/foo.txt
+   [file:foo.txt]
+   source=hpc1:/path/to/foo.txt
 
-      [file:bar.txt]
-      source=http://host/svn-repos/path/to/bar.txt
+   [file:bar.txt]
+   source=http://host/svn-repos/path/to/bar.txt
 
 In this example, a URI matching the pattern ``hpc*:*`` would use the
 ``rsync`` scheme to pull the source to the current host, and a URI matching

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -1,0 +1,725 @@
+Configuration
+=============
+
+
+Goals
+-----
+
+Suite configurations should be portable between users (at least at the same
+site). E.g.: another user should be able to run the same suite:
+
+* without making ANY changes to it.
+* without having to add/modify things in their $HOME/.profile.
+
+Input configurations should be programming language neutral.
+
+* Any processing logic should be application/version independent, generic and
+  future proof.
+* Data structure should be represented in formats easily understood and
+  manipulatable by a human and a computer.
+
+The life cycles of application configurations in a suite may differ from that
+of the suite.
+
+* The configuration of an application may be independent of the suite.
+* The configuration of an application should be portable between suitable
+  suites.
+
+The configurations are independent of the utilities. For example, the
+configuration metadata for the suite and application configurations will
+drive the Rose config editor GUI, but will not be bound or restricted by it.
+
+
+Configuration Format
+--------------------
+
+A configuration in Rose is normally represented by a directory with the
+following:
+
+* a configuration file in a modified INI file format.
+* (optionally) files containing data that cannot easily be represented by the
+  INI format.
+
+We have added the following conventions into our INI format:
+
+#. The file name is normally called rose*.conf, e.g. rose.conf,
+   rose-app.conf, rose-meta.conf, etc.
+#. Only a hash # in the beginning of a line starts a comment. Empty lines
+   and lines with only white spaces are ignored. There is no support for
+   trailing comments. Comments are normally ignored when a configuration file
+   is loaded. However, some comments are loaded if the following conditions
+   are met:
+   * Comment lines at the beginning of a configuration file up to but not
+     including the 1st blank line or the 1st setting are comment lines
+     associated with the file. They will re-appear at the top of the file
+     when it is re-dumped.
+   * Comment lines between a blank line and the next setting, and the
+     comment lines between the previous setting and the next setting are
+     comments associated with the next setting. The comment lines associated
+     with a setting will re-appear before the setting when the file is
+     re-dumped.
+#. Only the equal sign = is used to delimit a key-value pair - because the 
+   colon : may be used in keys of namelist declarations.
+#. A key-value pair declaration does not have to live under a section 
+   declaration. Such a declaration lives directly under the root level.
+#. Key-value pair declarations following a line with only [] are placed 
+   directly under the root level.
+#. Declarations are case sensitive. When dealing with case-insensitive
+   inputs such as Fortran logicals or numbers in scientific notation,
+   lowercase values should be used.
+#. When writing namelist inputs, keys should be lowercase.
+#. Declarations start at column 1. Continuations start at column >1.
+   * Each line is stripped of leading and trailing spaces.
+   * A newline \n character is prefixed to each continuation line.
+   * If a continuation line has a leading equal sign = character, it is
+     stripped from the line. This is useful for retaining leading white 
+     spaces in a continuation line.
+#. A single exclamation ! or a double exclamation !! in front of a section
+   (i.e. [!SECTION]) or key=value pair (i.e. !key=value) denotes an ignored
+   setting.
+   * E.g. It will be ignored in run time but may be used by other Rose
+     utilities.
+   * A single exclamation denotes a user-ignored setting.
+   * A double exclamation denotes a program-ignored setting. E.g. rose
+     config-edit may use a double exclamation to switch off a setting
+     according to the setting metadata.
+#. The open square bracket ([) and close square bracket (]) characters
+   cannot be used within a section declaration. E.g.
+   [[hello], [hello]], [hello [world] and beyond] should all be errors on
+   parsing.
+#. If a section is declared twice in a file, the later section will append
+   settings to the earlier one. If the same key in the same section is
+   declared twice, the later value will override the earlier one. This logic
+   applies to the state of a setting as well.
+#. Once the file is parsed, declaration ordering is insignificant. N.B. Do
+   not assume order of environment variables.
+#. Values of settings accept syntax such as $NAME or ${NAME} for environment
+   variable substitution.
+
+E.g.
+
+# This is line 1 of the comment for this file.
+# This is line 2 of the comment for this file.
+
+# This comment will be ignored.
+
+# This is a comment for section-1.
+[section-1]
+# This is a comment for key-1.
+key-1=value 1
+# This comment will be ignored.
+
+# This is line 1 of the comment for key-2.
+# This is line 2 of the comment for key-2.
+key-2=value 2 line 1
+      value 2 line 2
+# This is a comment for key-3.
+key-3=value 3 line 1
+     =    value 3 line 2 has leading identation.
+     =
+     =    value 3 line 3 is blank. This is line 4.
+
+# section-2 is user-ignored.
+[!section-2]
+key-4=value 4
+# ...
+
+[section-3]
+# key-5 is program ignored.
+!!key-5=value 5
+
+In this document, the shorthand SECTION=KEY=VALUE is used to represent a
+KEY=VALUE pair in a [SECTION] of an INI format file.
+
+
+Optional Configuration
+----------------------
+
+In a Rose configuration directory, we can add an opt/ sub-directory for
+optional configuration files. Optional configuration files contain additional
+configuration, which can be selected at run time to override the configuration
+in the main rose-${TYPE}.conf file. The name of each optional configuration
+should follow the syntax rose-${TYPE}-${KEY}.conf, where ${KEY} is a short
+name to describe the override functionality of the optional configuration
+file.
+
+A root level opts=KEY ... setting in the main configuration will tell the run
+time program to load the relevant optional configurations in the opt/
+sub-directory at run time. Individual Rose utilities may also read optional
+configuration keys from environment variables and/or command line options.
+
+Where multiple $KEY settings are given, the optional configurations are 
+applied in that order - for example, a setting:
+
+opts=ketchup mayonnaise
+
+implies loading the optional configuration rose-app-ketchup.conf and then the
+optional configuration rose-app-mayonnaise.conf, which may override the
+previous one.
+
+By default, a Rose command will fail if an optional configuration file is
+missing. However, if you put the optional configuration key in brackets,
+then the optional configuration file is allowed to be missing. E.g.:
+
+opts=ketchup (mayonnaise)
+
+In the above example, rose-app-mayonnaise.conf can be missing.
+
+Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run,
+etc) allow optional configurations to be selected at run time using:
+
+#. The ROSE_APP_OPT_CONF_KEYS Environment variables.
+#. The command line options --opt-conf-key=KEY or -O KEY.
+
+See reference of individual commands for detail.
+
+Note that by default optional configurations must exist else an error will
+be raised. To specify an optional configuration which may be missing write
+the name of the configuration inside parenthesis (e.g. (foo)).
+
+Optional Configurations and Metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Metadata utilities such as rose app-upgrade and rose macro treat each
+main + optional configuration as a separate entity to be transformed,
+upgraded, or validated. Use cases with more than one optional configuration
+are not handled.
+
+When transforming or upgrading, each optional configuration is treated
+separately and re-created after the transform as a functional difference
+from the main upgraded configuration.
+
+The logic for transforming or upgrading a main configuration C with optional
+configurations O1 and O2 into a new main configuration Ct and new optional
+configurations O1t and O2t can be represented like this:
+
+C => Ct
+C + O1 => C1t
+C + O2 => C2t
+O1t = C1t - Ct
+O2t = C2t - Ct
+
+
+Import Configuration
+--------------------
+
+A root level import=PATH1 PATH2... setting in the main configuration will
+tell Rose utilities to search for configurations at PATH1, PATH2 (and so on)
+and inherit configuration and files from them if found.
+
+At the moment, use of this is only encouraged for configuration metadata.
+
+
+Re-define Configuration at Run Time
+-----------------------------------
+
+Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run, etc)
+allow you to re-define configuration settings at run time using the
+--define=[SECTION]NAME=VALUE or -D [SECTION]NAME=VALUE options on the
+command line. This would add new settings or override any settings defined in
+the main and optional configurations. E.g.:
+
+(shell)$
+(shell)$
+(shell)$
+(shell)$
+(shell)$
+(shell)$
+
+# Set [env]FOO=foo, and [env]BAR=bar
+# (Overriding any original settings of [env]FOO or [env]BAR)
+rose task-run -D '[env]FOO=foo' -D '[env]BAR=bar'
+
+# Switch off [env]BAZ
+rose task-run -D '[env]!BAZ='
+
+
+Site and User Configuration
+---------------------------
+
+Aspects of some Rose utilities can be configured per installation via the
+site configuration file and per user via the user configuration file. Any
+configuration in the site configuration overrides the default, and any
+configuration in the user configuration overrides the site configuration and
+the default. Rose expects these files to be in the modified INI format
+described above. Rose utilities search for its site configuration at
+$ROSE_HOME/etc/rose.conf where $ROSE_HOME/bin/rose is the location of the
+rose command, and they search for the user configuration at
+$HOME/.metomi/rose.conf where $HOME is the home directory of the current
+user.
+
+Allowed settings in the site and user configuration files will be documented
+in a future version of this document. In the mean time, the settings are 
+documented as comments in the etc/rose.conf.example file of each
+distribution of Rose.
+
+You can also override many internal constants of the rose config edit and
+rosie go. To change the keyboard shortcut of the Find Next action in the
+config editor to F3, put the following lines in your user config file, and
+the setting will apply the next time you run rose config-edit:
+
+[rose-config-edit]
+accel-find-next=F3
+
+
+Suite Configuration
+-------------------
+
+The configuration and functionality of a suite will usually be covered by
+the use of cylc. In which case, most of the suite configuration will live
+in the cylc suite.rc file. Otherwise, a suite is just a directory of files.
+
+A suite directory may contain the following:
+
+* A file called rose-suite.conf, a configuration file in the modified INI
+  format described above. It stores the information on how to install the
+  suite. See below for detail.
+* A file called rose-suite.info, a configuration file in the modified INI
+  format described above. It describes the suite's purpose and identity, e.g.
+  the title, the description, the owner, the access control list, and other
+  information. Apart from a few standard fields, a suite is free to store
+  any information in this file. See below for detail.
+* An app/ directory of application configurations used by the suite.
+* A bin/ directory of scripts and utilities used by the suite.
+* An etc/ directory of other configurations and resources used the suite.
+  E.g. fcm make configurations.
+* A meta/ directory containing the suite's configuration metadata.
+* opt/ directory. For detail, see Optional Configuration.
+* Other items, as long as they do not clash with the scheduler's working
+  directories. E.g. for a cylc suite, log*/, share/, state/ and work/ should
+  be avoided.
+
+Suite Configuration: Suite Installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The suite install configuration file rose-suite.conf should contain the
+information on how to install the suite. It may have the following sections
+and root level options:
+
+[env]
+    Specify the environment variables to export to the suite daemon. The
+usual $NAME or ${NAME} syntax can be used in values to reference environment
+variables that are already defined before the suite runner is invoked.
+However, it is unsafe to reference other environment variables defined in
+this section. If the value of an environment variable setting begins with a
+tilde ~, all of the characters preceding the 1st slash / are considered a
+tilde-prefix. Where possible, a tilde-prefix is replaced with the home
+directory associated with the specified login name at run time. There are 2
+special environment variables which can be specified in this section:
+
+* ROSE_VERSION: If specified, the version of Rose that starts the suite
+  run must match the specified version.
+* CYLC_VERSION: If specified for a cylc suite, the Rose suite runner
+  will attempt to use this version of cylc.
+
+[jinja2:suite.rc]
+    For a cylc suite, if jinja2 assignments are required for suite.rc, they
+may be defined as key=value pairs in the [jinja2:suite.rc] section. The
+assignments will be inserted after the #!jinja2 line of the installed
+suite.rc file.
+[file:NAME]
+    Specify a file/directory to be installed. NAME should be a path
+relative to the run time $PWD.
+
+* E.g. file:app/APP=source=LOCATION.
+* See Appendix: File Creation Mode.
+
+It may have the following top level (no section) options:
+
+meta
+    Specify the configuration metadata for the suite. The section may be
+used by various Rose utilities, such as the config editor GUI. It can be
+used to specify the suite type.
+root-dir=LIST
+    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be
+a glob-like pattern for matching a host name. The DIR should be the root
+directory to install a suite run directory. E.g.:
+
+    root-dir=hpc*=$WORKDIR
+            =*=$DATADIR
+
+    In this example, rose suite-run of a suite with name $NAME will
+create ~/cylc-run/$NAME as a symbolic link to $DATADIR/cylc-run/$NAME/ on
+any machine, except those with their hostnames matching hpc*. In which
+case, it will create ~/cylc-run/$NAME as a symbolic link to
+$WORKDIR/cylc-run/$NAME/.
+root-dir{share}=LIST
+    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+glob-like pattern for matching a host name. The DIR should be the root
+directory where the suite's share/ directory should be created.
+root-dir{share/cycle}=LIST
+    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+glob-like pattern for matching a host name. The DIR should be the root
+directory where the suite's share/cycle/ directory should be created.
+root-dir{work}=LIST
+    A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
+glob-like pattern for matching a host name. The DIR should be the root
+directory where the suite's work/ directory for tasks should be created.
+root-dir-share=LIST
+    Deprecated. Same as root-dir{share}=LIST.
+root-dir-work=LIST
+    Deprecated. Same as root-dir{work}=LIST.
+
+Suite Configuration: Suite Information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The suite information file rose-suite.info should contain the information on
+identify and the purpose of the suite. It has no sections, only KEY=VALUE
+pairs. The owner, project and title settings are compulsory. Otherwise,
+any KEY=VALUE pairs can appear in this file. If the name of a KEY ends
+with -list, the value is expected to be a space-delimited list. The
+following keys are known to have special meanings:
+
+owner
+    Specify the user ID of the owner of the suite. The owner has full commit
+access to the suite. Only the owner can delete the suite, pass the suite's
+ownership to someone else or change the access-list.
+project
+    Specify the name of the project associated with the suite.
+title
+    Specify a short title of the suite.
+access-list
+    Specify a list of users with commit access to trunk of the suite. A * in
+the list means that anyone can commit to the trunk of the suite. Setting
+this blank or omitting the setting means that nobody apart from the owner
+can commit to the trunk. Only the suite owner can change the access list.
+description
+    Specify a long description of the suite.
+sub-project
+    Specify a sub-division of project, if applicable.
+
+
+Application Configuration
+-------------------------
+
+The configuration of an application is represented by a directory. It may
+contain the following:
+
+* rose-app.conf: a compulsory configuration file in the modified INI format.
+  See below for detail. It contains the following information:
+  * the command(s) to run.
+  * the metadata type for the application.
+  * the list of environment variables.
+  * other configurations that can be represented in un-ordered key=value
+    pairs, e.g. Fortran namelists.
+* file/ directory: other input files, e.g.:
+  * FCM configuration files (requires ordering of key=value pairs).
+  * STASH files.
+  * other configuration files that require more than section=key=value.
+
+  Files in this directory are copied to the working directory in run time.
+
+  Note: If there is a clash between a [file:*] section and a file under file/,
+  the setting in the [file:*] section takes precedence. E.g. Suppose we have
+  a file file/hello.txt. In the absence of [file:hello.txt], it will copy
+  file/hello.txt to $PWD/hello.txt in run time. However, if we have a
+  [file:hello.txt] section and a source=SOURCE setting, then it will install
+  the file from SOURCE instead. If we have [!file:hello.txt], then the file
+  will not be installed at all.
+* bin/ directory for e.g. scripts and executables used by the application at
+  run time. If a bin/ exists in the application configuration, it will 
+  prepended to the PATH environment variable at run time.
+* meta/ directory for the metadata of the application.
+* opt/ directory. For detail, see Optional Configuration.
+
+E.g. The application configuration directory may look like:
+
+./bin/
+./rose-app.conf
+./file/file1
+./file/file2
+./meta/rose-meta.conf
+./opt/rose-app-extra1.conf
+./opt/rose-app-extra2.conf
+...
+
+Application Configuration File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rose-app.conf contains a serialised data structure that is an unordered
+map (sections=) of unordered maps (keys=values). There can also be
+keys=values without a section, at the top level. The sections and keys can
+be:
+
+file-install-root
+    Root level setting. Specify the root directory to install file targets
+that are specified with a relative path.
+meta
+    Root level setting. Specify the configuration metadata for the application. This is ignored by the application runner, but may be used by other
+Rose utilities, such as the config editor GUI. It can be used to specify
+the application type.
+mode
+    Root level setting. Specify the name of a builtin application, instead of
+running a command specified in the [command] section. See also Running
+Tasks > rose task-run > Built-in Applications Selection
+[command]
+    Specify the command(s) to run. The default key can be used to define the
+default command to run. Other keys can be used to define alternate commands,
+which can be selected at run time.
+[env]
+    Specify input environment variables to the command, in KEY=VALUE pairs.
+The usual $NAME or ${NAME} syntax can be used in values to reference
+environment variables that are already defined when the application runner
+is invoked. However, it is unsafe to reference other environment variables
+defined in this section. Note: UNDEF is a special variable that is always
+undefined at run time. Reference to it will cause a failure at run time. It
+can be used to indicate that a value must be overridden at run time. If the
+value of an environment variable setting begins with a tilde ~, all of the
+characters preceding the 1st slash / are considered a tilde-prefix. Where
+possible, a tilde-prefix is replaced with the home directory associated with
+the specified login name at run time.
+[etc]
+    Specify misc. settings. Currently, only UM defs for science sections are
+thought to require this section.
+[file:NAME]
+    Specify a file/directory to be generated by the application runner at
+run time. NAME should be a path relative to the run time $PWD, or STDIN.
+
+* E.g. file:app/APP=source=LOCATION.
+* See Appendix: File Creation Mode.
+
+[namelist:NAME]
+    Specify a namelist with the group name called NAME, which can be
+referred to by a source setting of a file. Each setting in a namelist:NAME
+section is a KEY=VALUE pair exactly like a normal Fortran namelist, but
+without the trailing comma.
+[namelist:NAME(SORT-INDEX)]
+    Same as [namelist:NAME] but:
+
+* It allows the source setting of a file to refer to all
+[namelist:NAME(SORT-INDEX)] as namelist:NAME(:), and the namelist groups
+will be sorted alphanumerically by the SORT-INDEX.
+* It allows different namelist files to have namelists with the same group
+name. These will all inherit the same group configuration metadata
+(from [namelist:NAME]).
+
+[namelist:NAME{CATEGORY}] or [namelist:NAME{CATEGORY}(SORT-INDEX)]
+    Same as [namelist:NAME(SORT-INDEX)] but:
+
+* An alternate way for grouping namelists. This allows the same namelist
+to have different usage and configuration metadata according to its
+category. Namelists will inherit configuration metadata from their basic
+group [namelist:NAME] as well as from their specific category
+[namelist:NAME{CATEGORY}].
+
+[poll]
+    Specify prerequisites to poll for before running the actual application.
+3 types of tests can be performed:
+
+    all-files: A list of space delimited list of file paths. This test passes
+only if all file paths in the list exist.
+
+    any-files: A list of space delimited list of file paths. This test passes
+if any file path in the list exists.
+
+    test: A shell command. This test passes if the command returns a 0 (zero)
+return code.
+
+    Normally, the all-files and any-files tests both test for the existence
+of file paths. If this is not enough, e.g. you want to test for the existence
+of a string in each file, you can specify a file-test to do a grep. E.g.:
+
+    all-files=file1 file2
+    file-test=test -e {} && grep -q 'hello' {}
+
+    At runtime, any {} pattern in the above would be replaced with the name
+of the file. The above make sure that both file1 and file2 exist and that
+they both contain the string hello.
+
+    The above tests will only be performed once when the application runner
+starts. If a list of delays are added, the tests will be performed a number
+of times with delays between them. If the prerequisites are still not met
+after the number of delays, the application runner will fail with a time out.
+The list is a comma-separated list. The syntax looks like [n*][DURATION],
+where DURATION is an ISO 8601 duration such as PT5S (5 seconds) or
+PT10M (10 minutes), and n is an optional number of times to repeat it. E.g.:
+
+    # Default
+    delays=0
+
+    # Poll 1 minute after the runner begins, repeat every minute 10 times
+    delays=10*PT1M
+
+    # Poll when runner begins,
+    # repeat every 10 seconds 6 times,
+    # repeat every minute 60 times,
+    # repeat once after 1 hour
+    delays=0,6*PT10S,60*PT1M,PT1H
+
+Application Configuration File: Built-in Application: fcm_make
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See Running Tasks > rose task-run > Built-in Application: fcm_make.
+
+Application Configuration File: Built-in Application: rose_ana
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See Running Tasks > rose task-run > Built-in Application: rose_ana and
+rose stem > Analysing output with rose_ana.
+
+Application Configuration File: Built-in Application: rose_arch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See Running Tasks > rose task-run > Built-in Application: rose_arch.
+
+Application Configuration File: Built-in Application: rose_prune
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See Running Tasks > rose task-run > Built-in Application: rose_prune.
+
+
+Configuration Metadata
+----------------------
+
+See Configuration Metadata.
+
+
+Appendix: File Creation Mode
+----------------------------
+
+A [file:TARGET] section may have the following settings:
+
+source
+    A space delimited list of sources for generating this file. A source can
+be the path to a regular file or directory in the file system (globbing is
+also supported - e.g. using "*.conf" to mean all .conf files), or it may be
+a URI to a resource. If a source is a URI, it may point to a section with a
+supported scheme in the current configuration, e.g. a namelist:NAME section.
+Otherwise the URI must be in a supported scheme or be given sufficient
+information for the system to determine its scheme, e.g. via the root level
+schemes setting described below.
+
+    Normally, a source that does not exist would trigger an error in run
+time. However, it may be useful to have an optional source for a file
+sometimes. In which case, the syntax source=(SOURCE) can be used to specify
+an optional source. E.g. source=namelist:foo (namelist:bar) would allow
+namelist:bar to be missing or ignored without an error.
+checksum
+    The expected MD5 checksum of the target. If specified, the file
+generation will fail if the actual checksum of the target does not match
+with this setting. This setting is only meaningful if TARGET is a regular
+file or a symbolic link to a regular file. N.B. An empty value for
+checksum tells the system to report the target checksum in verbose mode.
+mode
+    auto (default), mkdir, symlink or symlink+. See below.
+
+The following is a list of all the supported usages:
+
+mode=auto,source=
+    Target is an empty file.
+mode=auto,source=SOURCE
+    Target is a copy of SOURCE.
+mode=auto,source=SOURCE-LIST
+    Target is created by concatenating the contents of SOURCE-LIST. The
+sources should either be all files or all directories.
+mode=mkdir
+    Target is a directory.
+mode=symlink,source=SOURCE
+    Target is created as a symlink of an FS SOURCE. N.B. In this mode,
+SOURCE must be a single source. SOURCE does not have to exist when the
+symbolic link is created.
+mode=symlink+,source=SOURCE
+    Target is created as a symlink of an FS SOURCE. N.B. In this mode,
+SOURCE must be a single source. SOURCE must exist when the symbolic link
+is created.
+
+The root level schemes setting: While the system would attempt to
+automatically detect the scheme of a source, the name of the source can
+sometimes be ambiguous. E.g. A URL with a http scheme can be a path in a
+version control system, or a path to a plain file. The root level schemes
+setting can be used to help the system to do the right thing. The general
+syntax of the value of the root level schemes setting looks like:
+
+schemes=PATTERN-1=SCHEME-1
+       =PATTERN-2=SCHEME-2
+
+E.g.:
+
+schemes=hpc*:*=rsync
+       =http://host/svn-repos/*=svn
+
+[file:foo.txt]
+source=hpc1:/path/to/foo.txt
+
+[file:bar.txt]
+source=http://host/svn-repos/path/to/bar.txt
+
+In this example, a URI matching the pattern hpc*:* would use the rsync
+scheme to pull the source to the current host, and a URI matching the
+pattern http://host/svn-repos/* would use the svn scheme. For all other
+URIs, the system will try to make an intelligent guess.
+
+The system will always match a URI in the order as specified by the setting
+to avoid ambiguity.
+
+The system has built-in support for the following schemes:
+
+fs
+    The file system scheme. If a URI looks like an existing path in the
+file system, this scheme will be used.
+namelist
+    The namelist scheme. Refer to namelist:NAME sections in the configuration
+file.
+svn
+    The Subversion scheme. The location is a Subversion URL or an FCM
+location keyword. A URI with these schemes svn, svn+ssh and fcm are
+automatically recognised.
+rsync
+    This scheme is useful for pulling a file or directory from a remote
+host using rsync via ssh. A URI should have the form HOST:PATH. (Note: If
+required, you can use the User setting in ~/.ssh/config to specify the user
+ID for logging into HOST.)
+
+The application launcher will use the following logic to determine the
+root directory to install file targets with a relative path:
+
+    If the setting file-install-root=PATH is specified (at the root level)
+in the application configuration file, its value will be used.
+    If the environment variable ROSE_FILE_INSTALL_ROOT is specified, its
+value will be used.
+    Otherwise, the working directory of the task will be used.
+
+
+Appendix: rose-ana configuration format
+---------------------------------------
+
+The rose-ana builtin application reads information about which analysis
+steps it should perform from the rose-app.conf file for that task. Each of
+the section names (in square brackets) which describe an analysis step must
+follow a particular format:
+
+* the name must begin with ana:. This is required for rose-ana to recognise
+  it as a valid section.
+* the next part gives the name of the class within one of the analysis
+  modules, including namespace information; for example to use the built-in
+  FilePattern class from the grepper module you would provide the name
+  grepper.FilePattern.
+* finally an expression within parentheses which may contain any string;
+  this should be used to make comparisons using the same class unique, but
+  can otherwise simply act as a description or note.
+
+The content within each of these sections consists of a series of key-value
+option pairs; just like other standard Rose apps. However the availability
+of options for a given section is specified and controlled by the class
+rather than the meta-data. This makes it easy to provide your own analysis
+modules without requiring changes to Rose itself.
+
+Therefore you should consult the documentation or source code of the
+analysis module you wish to use for details of which options it supports.
+Additionally, some special treatment is applied to all options depending
+on what they contain:
+
+* Environment vars: If the option contains any words prefixed by $ they will
+  be substituted for the equivalent environment variable, if one is available.
+* Lists: If the option contains newlines it will be returned as a list of
+  strings automatically.
+* Argument substitution: If the option contains one or more pairs of empty
+  curved-parentheses {} the option will be returned multiple times with the
+  parentheses substituted once for each argument passed to rose task-run
+
+The app may also define a configuration section; [ana:config], whose
+key-value pairs define app-wide settings that are passed through to the
+analysis classes. In the same way that the task options are dependent on
+the class definition; interpretation of the config options is done by the
+lass(es), so their documentation or source code should be consulted for
+details.

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -1,3 +1,12 @@
+.. include:: ../hyperlinks.rst
+   :start-line: 1
+
+.. _INI file: https://en.wikipedia.org/wiki/INI_file
+.. _cylc: http://cylc.github.io/cylc/
+.. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
+.. _User: http://man.openbsd.org/ssh_config#User
+
+
 Configuration
 =============
 
@@ -30,13 +39,15 @@ configuration metadata for the suite and application configurations will
 drive the Rose config editor GUI, but will not be bound or restricted by it.
 
 
+.. _conf-format:
+
 Configuration Format
 --------------------
 
 A configuration in Rose is normally represented by a directory with the
 following:
 
-* a configuration file in a modified INI file format.
+* a configuration file in a modified `INI file`_ format.
 * (optionally) files containing data that cannot easily be represented by the
   INI format.
 
@@ -137,6 +148,7 @@ We have added the following conventions into our INI format:
 In this document, the shorthand ``SECTION=KEY=VALUE`` is used to represent a
 ``KEY=VALUE`` pair in a ``[SECTION]`` of an INI format file.
 
+.. _opt-config:
 
 Optional Configuration
 ----------------------
@@ -175,8 +187,9 @@ then the optional configuration file is allowed to be missing. E.g.:
 
 In the above example, ``rose-app-mayonnaise.conf`` can be missing.
 
-Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run,
-etc) allow optional configurations to be selected at run time using:
+Some Rose utilities (e.g. :ref:`command-rose-suite-run`,
+:ref:`command-rose-task-run`, :ref:`command-rose-app-run`, etc) allow
+optional configurations to be selected at run time using:
 
 #. The ROSE_APP_OPT_CONF_KEYS Environment variables.
 #. The command line options ``--opt-conf-key=KEY`` or ``-O KEY``.
@@ -226,11 +239,12 @@ At the moment, use of this is only encouraged for configuration metadata.
 Re-define Configuration at Run Time
 -----------------------------------
 
-Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run, etc)
-allow you to re-define configuration settings at run time using the
-``--define=[SECTION]NAME=VALUE`` or ``-D [SECTION]NAME=VALUE`` options on the
-command line. This would add new settings or override any settings defined in
-the main and optional configurations. E.g.:
+Some Rose utilities (e.g. :ref:`command-rose-suite-run`,
+:ref:`command-rose-task-run`, :ref:`command-rose-app-run`, etc) allow you
+to re-define configuration settings at run time using the
+``--define=[SECTION]NAME=VALUE`` or ``-D [SECTION]NAME=VALUE`` options on
+the command line. This would add new settings or override any settings
+defined in the main and optional configurations. E.g.:
 
    .. code-block:: bash
 
@@ -241,6 +255,8 @@ the main and optional configurations. E.g.:
       (shell)$ # Switch off [env]BAZ
       (shell)$ rose task-run -D '[env]!BAZ='
 
+
+.. _site-n-user-conf:
 
 Site and User Configuration
 ---------------------------
@@ -276,7 +292,7 @@ Suite Configuration
 -------------------
 
 The configuration and functionality of a suite will usually be covered by
-the use of cylc. In which case, most of the suite configuration will live
+the use of `cylc`_. In which case, most of the suite configuration will live
 in the cylc ``suite.rc`` file. Otherwise, a suite is just a directory of
 files.
 
@@ -284,21 +300,24 @@ A suite directory may contain the following:
 
 * A file called ``rose-suite.conf``, a configuration file in the modified INI
   format described above. It stores the information on how to install the
-  suite. See below for detail.
+  suite. See :ref:`below <suite-config-suite-inst>` for detail.
 * A file called ``rose-suite.info``, a configuration file in the modified INI
   format described above. It describes the suite's purpose and identity, e.g.
   the title, the description, the owner, the access control list, and other
   information. Apart from a few standard fields, a suite is free to store
-  any information in this file. See below for detail.
+  any information in this file. See :ref:`below <suite-config-suite-info>`
+  for detail.
 * An ``app/`` directory of application configurations used by the suite.
 * A ``bin/`` directory of scripts and utilities used by the suite.
 * An ``etc/`` directory of other configurations and resources used the suite.
   E.g. fcm make configurations.
 * A ``meta/`` directory containing the suite's configuration metadata.
-* ``opt/`` directory. For detail, see Optional Configuration.
+* ``opt/`` directory. For detail, see :ref:`opt-config`.
 * Other items, as long as they do not clash with the scheduler's working
   directories. E.g. for a cylc suite, ``log*/``, ``share/``, ``state/`` and
   ``work/`` should be avoided.
+
+.. _suite-config-suite-inst:
 
 Suite Configuration: Suite Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -325,17 +344,17 @@ and root level options:
     will attempt to use this version of cylc.
 
 ``[jinja2:suite.rc]``
-  For a cylc suite, if jinja2 assignments are required for ``suite.rc``, they
-  may be defined as ``key=value`` pairs in the ``[jinja2:suite.rc]`` section.
-  The assignments will be inserted after the ``#!jinja2`` line of the
-  installed ``suite.rc`` file.
+  For a cylc suite, if `Jinja2`_ assignments are required for
+  ``suite.rc``, they may be defined as ``key=value`` pairs in the
+  ``[jinja2:suite.rc]`` section. The assignments will be inserted after the
+  ``#!jinja2`` line of the installed ``suite.rc`` file.
 
 ``[file:NAME]``
   Specify a file/directory to be installed. ``NAME`` should be a path
   relative to the run time ``$PWD``.
 
   * E.g. ``file:app/APP=source=LOCATION``.
-  * See Appendix: File Creation Mode.
+  * See :ref:`Appendix: File Creation Mode <app-file-cre-mode>`.
 
 It may have the following top level (no section) options:
 
@@ -383,6 +402,8 @@ It may have the following top level (no section) options:
 ``root-dir-work=LIST``
   Deprecated. Same as ``root-dir{work}=LIST``.
 
+.. _suite-config-suite-info:
+
 Suite Configuration: Suite Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -424,7 +445,8 @@ The configuration of an application is represented by a directory. It may
 contain the following:
 
 * ``rose-app.conf``: a compulsory configuration file in the modified INI format.
-  See below for detail. It contains the following information:
+  See :ref:`below <app-conf-file>` for detail. It contains the following
+  information:
 
   * the command(s) to run.
   * the metadata type for the application.
@@ -452,7 +474,8 @@ contain the following:
   at run time. If a ``bin/`` exists in the application configuration, it will 
   prepended to the ``PATH`` environment variable at run time.
 * ``meta/`` directory for the metadata of the application.
-* ``opt/`` directory. For detail, see Optional Configuration.
+* ``opt/`` directory. For detail, see
+  :ref:`Optional Configuration <opt-config>`.
 
 E.g. The application configuration directory may look like:
 
@@ -466,6 +489,8 @@ E.g. The application configuration directory may look like:
       ./opt/rose-app-extra1.conf
       ./opt/rose-app-extra2.conf
       ...
+
+.. _app-conf-file:
 
 Application Configuration File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -489,6 +514,8 @@ keys can be:
   Root level setting. Specify the name of a builtin application, instead of
   running a command specified in the ``[command]`` section. See also Running
   Tasks > rose task-run > Built-in Applications Selection
+
+.. TODO - create internal link to section on above line
 
 ``[command]``
   Specify the command(s) to run. The default key can be used to define the
@@ -518,7 +545,7 @@ keys can be:
   ``STDIN``.
 
   * E.g. ``file:app/APP=source=LOCATION``.
-  * See Appendix: File Creation Mode.
+  * See :ref:`Appendix: File Creation Mode <app-file-cre-mode>`.
 
 ``[namelist:NAME]``
   Specify a namelist with the group name called ``NAME``, which can be
@@ -577,8 +604,8 @@ keys can be:
   number of times with delays between them. If the prerequisites are still
   not met  after the number of delays, the application runner will fail with
   a time out. The list is a comma-separated list. The syntax looks like
-  ``[n*][DURATION]``, where ``DURATION`` is an ISO 8601 duration such as
-  ``PT5S`` (5 seconds) or ``PT10M`` (10 minutes), and ``n`` is an optional
+  ``[n*][DURATION]``, where ``DURATION`` is an `ISO 8601 duration`_ such
+  as ``PT5S`` (5 seconds) or ``PT10M`` (10 minutes), and ``n`` is an optional
   number of times to repeat it. E.g.:
 
   .. code-block:: rose
@@ -600,28 +627,38 @@ Application Configuration File: Built-in Application: fcm_make
 
 See Running Tasks > rose task-run > Built-in Application: fcm_make.
 
+.. TODO - create internal link to section on above line
+
 Application Configuration File: Built-in Application: rose_ana
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See Running Tasks > rose task-run > Built-in Application: rose_ana and
 rose stem > Analysing output with rose_ana.
 
+.. TODO - create internal (2 x) links to sections on above line
+
 Application Configuration File: Built-in Application: rose_arch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See Running Tasks > rose task-run > Built-in Application: rose_arch.
+
+.. TODO - create internal link to section on above line
 
 Application Configuration File: Built-in Application: rose_prune
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See Running Tasks > rose task-run > Built-in Application: rose_prune.
 
+.. TODO - create internal link to section on above line
+
 
 Configuration Metadata
 ----------------------
 
-See Configuration Metadata.
+See :ref:`conf-meta`.
 
+
+.. _app-file-cre-mode:
 
 Appendix: File Creation Mode
 ----------------------------
@@ -729,7 +766,7 @@ The system has built-in support for the following schemes:
 ``rsync``
   This scheme is useful for pulling a file or directory from a remote
   host using ``rsync`` via ``ssh``. A URI should have the form ``HOST:PATH``.
-  (Note: If required, you can use the User setting in ``~/.ssh/config`` to
+  (Note: If required, you can use the `User`_ setting in ``~/.ssh/config`` to
   specify the user ID for logging into ``HOST``.)
 
 The application launcher will use the following logic to determine the

--- a/sphinx/user-guide/configuration.rst
+++ b/sphinx/user-guide/configuration.rst
@@ -9,7 +9,7 @@ Suite configurations should be portable between users (at least at the same
 site). E.g.: another user should be able to run the same suite:
 
 * without making ANY changes to it.
-* without having to add/modify things in their $HOME/.profile.
+* without having to add/modify things in their ``$HOME/.profile``.
 
 Input configurations should be programming language neutral.
 
@@ -42,9 +42,9 @@ following:
 
 We have added the following conventions into our INI format:
 
-#. The file name is normally called rose*.conf, e.g. rose.conf,
-   rose-app.conf, rose-meta.conf, etc.
-#. Only a hash # in the beginning of a line starts a comment. Empty lines
+#. The file name is normally called ``rose\*.conf``, e.g. ``rose.conf``,
+   ``rose-app.conf``, ``rose-meta.conf``, etc.
+#. Only a hash ``#`` in the beginning of a line starts a comment. Empty lines
    and lines with only white spaces are ignored. There is no support for
    trailing comments. Comments are normally ignored when a configuration file
    is loaded. However, some comments are loaded if the following conditions
@@ -60,11 +60,11 @@ We have added the following conventions into our INI format:
      with a setting will re-appear before the setting when the file is
      re-dumped.
 
-#. Only the equal sign = is used to delimit a key-value pair - because the 
-   colon : may be used in keys of namelist declarations.
+#. Only the equal sign ``=`` is used to delimit a key-value pair - because the 
+   colon ``:`` may be used in keys of namelist declarations.
 #. A key-value pair declaration does not have to live under a section 
    declaration. Such a declaration lives directly under the root level.
-#. Key-value pair declarations following a line with only [] are placed 
+#. Key-value pair declarations following a line with only ``[]`` are placed 
    directly under the root level.
 #. Declarations are case sensitive. When dealing with case-insensitive
    inputs such as Fortran logicals or numbers in scientific notation,
@@ -73,14 +73,14 @@ We have added the following conventions into our INI format:
 #. Declarations start at column 1. Continuations start at column >1.
 
    * Each line is stripped of leading and trailing spaces.
-   * A newline \n character is prefixed to each continuation line.
-   * If a continuation line has a leading equal sign = character, it is
+   * A newline ``\n`` character is prefixed to each continuation line.
+   * If a continuation line has a leading equal sign ``=`` character, it is
      stripped from the line. This is useful for retaining leading white 
      spaces in a continuation line.
 
-#. A single exclamation ! or a double exclamation !! in front of a section
-   (i.e. [!SECTION]) or key=value pair (i.e. !key=value) denotes an ignored
-   setting.
+#. A single exclamation ``!`` or a double exclamation ``!!`` in front of a
+   section (i.e. ``[!SECTION]``) or key=value pair (i.e. ``!key=value``)
+   denotes an ignored setting.
 
    * E.g. It will be ignored in run time but may be used by other Rose
      utilities.
@@ -89,18 +89,18 @@ We have added the following conventions into our INI format:
      config-edit may use a double exclamation to switch off a setting
      according to the setting metadata.
 
-#. The open square bracket ([) and close square bracket (]) characters
+#. The open square bracket (``[``) and close square bracket (``]``) characters
    cannot be used within a section declaration. E.g.
-   [[hello], [hello]], [hello [world] and beyond] should all be errors on
-   parsing.
+   ``[[hello]``, ``[hello]]``, ``[hello [world] and beyond]`` should all be
+   errors on parsing.
 #. If a section is declared twice in a file, the later section will append
    settings to the earlier one. If the same key in the same section is
    declared twice, the later value will override the earlier one. This logic
    applies to the state of a setting as well.
 #. Once the file is parsed, declaration ordering is insignificant. N.B. Do
    not assume order of environment variables.
-#. Values of settings accept syntax such as $NAME or ${NAME} for environment
-   variable substitution.
+#. Values of settings accept syntax such as ``$NAME`` or ``${NAME}`` for
+   environment variable substitution.
 
    .. code-block:: cylc
 
@@ -134,36 +134,36 @@ We have added the following conventions into our INI format:
       # key-5 is program ignored.
       !!key-5=value 5
 
-In this document, the shorthand SECTION=KEY=VALUE is used to represent a
-KEY=VALUE pair in a [SECTION] of an INI format file.
+In this document, the shorthand ``SECTION=KEY=VALUE`` is used to represent a
+``KEY=VALUE`` pair in a ``[SECTION]`` of an INI format file.
 
 
 Optional Configuration
 ----------------------
 
-In a Rose configuration directory, we can add an opt/ sub-directory for
+In a Rose configuration directory, we can add an ``opt/`` sub-directory for
 optional configuration files. Optional configuration files contain additional
 configuration, which can be selected at run time to override the configuration
-in the main rose-${TYPE}.conf file. The name of each optional configuration
-should follow the syntax rose-${TYPE}-${KEY}.conf, where ${KEY} is a short
-name to describe the override functionality of the optional configuration
-file.
+in the main ``rose-${TYPE}.conf`` file. The name of each optional configuration
+should follow the syntax ``rose-${TYPE}-${KEY}.conf``, where ``${KEY}`` is a
+short name to describe the override functionality of the optional
+configuration file.
 
-A root level opts=KEY ... setting in the main configuration will tell the run
-time program to load the relevant optional configurations in the opt/
+A root level ``opts=KEY ...`` setting in the main configuration will tell the
+run time program to load the relevant optional configurations in the ``opt/``
 sub-directory at run time. Individual Rose utilities may also read optional
 configuration keys from environment variables and/or command line options.
 
-Where multiple $KEY settings are given, the optional configurations are 
+Where multiple ``$KEY`` settings are given, the optional configurations are 
 applied in that order - for example, a setting:
 
    .. code-block:: rose
 
       opts=ketchup mayonnaise
 
-implies loading the optional configuration rose-app-ketchup.conf and then the
-optional configuration rose-app-mayonnaise.conf, which may override the
-previous one.
+implies loading the optional configuration ``rose-app-ketchup.conf`` and then
+the optional configuration ``rose-app-mayonnaise.conf``, which may override
+the previous one.
 
 By default, a Rose command will fail if an optional configuration file is
 missing. However, if you put the optional configuration key in brackets,
@@ -173,24 +173,24 @@ then the optional configuration file is allowed to be missing. E.g.:
 
       opts=ketchup (mayonnaise)
 
-In the above example, rose-app-mayonnaise.conf can be missing.
+In the above example, ``rose-app-mayonnaise.conf`` can be missing.
 
 Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run,
 etc) allow optional configurations to be selected at run time using:
 
 #. The ROSE_APP_OPT_CONF_KEYS Environment variables.
-#. The command line options --opt-conf-key=KEY or -O KEY.
+#. The command line options ``--opt-conf-key=KEY`` or ``-O KEY``.
 
 See reference of individual commands for detail.
 
 Note that by default optional configurations must exist else an error will
 be raised. To specify an optional configuration which may be missing write
-the name of the configuration inside parenthesis (e.g. (foo)).
+the name of the configuration inside parenthesis (e.g. ``(foo)``).
 
 Optional Configurations and Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Metadata utilities such as rose app-upgrade and rose macro treat each
+Metadata utilities such as ``rose app-upgrade`` and ``rose macro`` treat each
 main + optional configuration as a separate entity to be transformed,
 upgraded, or validated. Use cases with more than one optional configuration
 are not handled.
@@ -199,9 +199,10 @@ When transforming or upgrading, each optional configuration is treated
 separately and re-created after the transform as a functional difference
 from the main upgraded configuration.
 
-The logic for transforming or upgrading a main configuration C with optional
-configurations O1 and O2 into a new main configuration Ct and new optional
-configurations O1t and O2t can be represented like this:
+The logic for transforming or upgrading a main configuration ``C`` with
+optional configurations ``O1`` and ``O2`` into a new main configuration ``Ct``
+and new optional configurations ``O1t`` and ``O2t`` can be represented like
+this:
 
    .. code-block:: none
 
@@ -215,9 +216,9 @@ configurations O1t and O2t can be represented like this:
 Import Configuration
 --------------------
 
-A root level import=PATH1 PATH2... setting in the main configuration will
-tell Rose utilities to search for configurations at PATH1, PATH2 (and so on)
-and inherit configuration and files from them if found.
+A root level ``import=PATH1 PATH2...`` setting in the main configuration will
+tell Rose utilities to search for configurations at ``PATH1``, ``PATH2`` (and
+so on) and inherit configuration and files from them if found.
 
 At the moment, use of this is only encouraged for configuration metadata.
 
@@ -227,7 +228,7 @@ Re-define Configuration at Run Time
 
 Some Rose utilities (e.g. rose suite-run, rose task-run, rose app-run, etc)
 allow you to re-define configuration settings at run time using the
---define=[SECTION]NAME=VALUE or -D [SECTION]NAME=VALUE options on the
+``--define=[SECTION]NAME=VALUE`` or ``-D [SECTION]NAME=VALUE`` options on the
 command line. This would add new settings or override any settings defined in
 the main and optional configurations. E.g.:
 
@@ -250,20 +251,20 @@ configuration in the site configuration overrides the default, and any
 configuration in the user configuration overrides the site configuration and
 the default. Rose expects these files to be in the modified INI format
 described above. Rose utilities search for its site configuration at
-$ROSE_HOME/etc/rose.conf where $ROSE_HOME/bin/rose is the location of the
-rose command, and they search for the user configuration at
-$HOME/.metomi/rose.conf where $HOME is the home directory of the current
-user.
+``$ROSE_HOME/etc/rose.conf`` where ``$ROSE_HOME/bin/rose`` is the location of
+the rose command, and they search for the user configuration at
+``$HOME/.metomi/rose.conf`` where ``$HOME`` is the home directory of the
+current user.
 
 Allowed settings in the site and user configuration files will be documented
 in a future version of this document. In the mean time, the settings are 
-documented as comments in the etc/rose.conf.example file of each
+documented as comments in the ``etc/rose.conf.example`` file of each
 distribution of Rose.
 
-You can also override many internal constants of the rose config edit and
-rosie go. To change the keyboard shortcut of the Find Next action in the
-config editor to F3, put the following lines in your user config file, and
-the setting will apply the next time you run rose config-edit:
+You can also override many internal constants of the ``rose config edit`` and
+``rosie go``. To change the keyboard shortcut of the ``Find Next`` action in
+the config editor to ``F3``, put the following lines in your user config file,
+and the setting will apply the next time you run ``rose config-edit``:
 
    .. code-block:: rose
 
@@ -276,140 +277,144 @@ Suite Configuration
 
 The configuration and functionality of a suite will usually be covered by
 the use of cylc. In which case, most of the suite configuration will live
-in the cylc suite.rc file. Otherwise, a suite is just a directory of files.
+in the cylc ``suite.rc`` file. Otherwise, a suite is just a directory of
+files.
 
 A suite directory may contain the following:
 
-* A file called rose-suite.conf, a configuration file in the modified INI
+* A file called ``rose-suite.conf``, a configuration file in the modified INI
   format described above. It stores the information on how to install the
   suite. See below for detail.
-* A file called rose-suite.info, a configuration file in the modified INI
+* A file called ``rose-suite.info``, a configuration file in the modified INI
   format described above. It describes the suite's purpose and identity, e.g.
   the title, the description, the owner, the access control list, and other
   information. Apart from a few standard fields, a suite is free to store
   any information in this file. See below for detail.
-* An app/ directory of application configurations used by the suite.
-* A bin/ directory of scripts and utilities used by the suite.
-* An etc/ directory of other configurations and resources used the suite.
+* An ``app/`` directory of application configurations used by the suite.
+* A ``bin/`` directory of scripts and utilities used by the suite.
+* An ``etc/`` directory of other configurations and resources used the suite.
   E.g. fcm make configurations.
-* A meta/ directory containing the suite's configuration metadata.
-* opt/ directory. For detail, see Optional Configuration.
+* A ``meta/`` directory containing the suite's configuration metadata.
+* ``opt/`` directory. For detail, see Optional Configuration.
 * Other items, as long as they do not clash with the scheduler's working
-  directories. E.g. for a cylc suite, log*/, share/, state/ and work/ should
-  be avoided.
+  directories. E.g. for a cylc suite, ``log*/``, ``share/``, ``state/`` and
+  ``work/`` should be avoided.
 
 Suite Configuration: Suite Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The suite install configuration file rose-suite.conf should contain the
+The suite install configuration file ``rose-suite.conf`` should contain the
 information on how to install the suite. It may have the following sections
 and root level options:
 
-[env]
+``[env]``
   Specify the environment variables to export to the suite daemon. The
-  usual $NAME or ${NAME} syntax can be used in values to reference environment
-  variables that are already defined before the suite runner is invoked.
-  However, it is unsafe to reference other environment variables defined in
-  this section. If the value of an environment variable setting begins with a
-  tilde ~, all of the characters preceding the 1st slash / are considered a
-  tilde-prefix. Where possible, a tilde-prefix is replaced with the home
-  directory associated with the specified login name at run time. There are 2
-  special environment variables which can be specified in this section:
+  usual ``$NAME`` or ``${NAME}`` syntax can be used in values to reference
+  environment variables that are already defined before the suite runner is
+  invoked. However, it is unsafe to reference other environment variables
+  defined in this section. If the value of an environment variable setting
+  begins with a  tilde ``~``, all of the characters preceding the 1st slash
+  ``/`` are considered a tilde-prefix. Where possible, a tilde-prefix is
+  replaced with the home  directory associated with the specified login name
+  at run time. There are 2  special environment variables which can be
+  specified in this section:
 
-  * ROSE_VERSION: If specified, the version of Rose that starts the suite
+  * ``ROSE_VERSION``: If specified, the version of Rose that starts the suite
     run must match the specified version.
-  * CYLC_VERSION: If specified for a cylc suite, the Rose suite runner
+  * ``CYLC_VERSION``: If specified for a cylc suite, the Rose suite runner
     will attempt to use this version of cylc.
 
-[jinja2:suite.rc]
-  For a cylc suite, if jinja2 assignments are required for suite.rc, they
-  may be defined as key=value pairs in the [jinja2:suite.rc] section. The
-  assignments will be inserted after the #!jinja2 line of the installed
-  suite.rc file.
+``[jinja2:suite.rc]``
+  For a cylc suite, if jinja2 assignments are required for ``suite.rc``, they
+  may be defined as ``key=value`` pairs in the ``[jinja2:suite.rc]`` section.
+  The assignments will be inserted after the ``#!jinja2`` line of the
+  installed ``suite.rc`` file.
 
-[file:NAME]
-  Specify a file/directory to be installed. NAME should be a path
-  relative to the run time $PWD.
+``[file:NAME]``
+  Specify a file/directory to be installed. ``NAME`` should be a path
+  relative to the run time ``$PWD``.
 
-  * E.g. file:app/APP=source=LOCATION.
+  * E.g. ``file:app/APP=source=LOCATION``.
   * See Appendix: File Creation Mode.
 
 It may have the following top level (no section) options:
 
-meta
+``meta``
   Specify the configuration metadata for the suite. The section may be
   used by various Rose utilities, such as the config editor GUI. It can be
   used to specify the suite type.
 
-root-dir=LIST
-  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be
-  a glob-like pattern for matching a host name. The DIR should be the root
-  directory to install a suite run directory. E.g.:
+``root-dir=LIST``
+  A new line delimited list of ``PATTERN=DIR`` pairs. The ``PATTERN`` should
+  be a glob-like pattern for matching a host name. The ``DIR`` should be the
+  root directory to install a suite run directory. E.g.:
 
   .. code-block:: rose
 
      root-dir=hpc*=$WORKDIR
              =*=$DATADIR
 
-  In this example, rose suite-run of a suite with name $NAME will
-  create ~/cylc-run/$NAME as a symbolic link to $DATADIR/cylc-run/$NAME/ on
-  any machine, except those with their hostnames matching hpc*. In which
-  case, it will create ~/cylc-run/$NAME as a symbolic link to
-  $WORKDIR/cylc-run/$NAME/.
+  In this example, ``rose suite-run`` of a suite with name ``$NAME`` will
+  create ``~/cylc-run/$NAME`` as a symbolic link to
+  ``$DATADIR/cylc-run/$NAME/`` on any machine, except those with their
+  hostnames matching ``hpc*``. In which case, it will create
+  ``~/cylc-run/$NAME`` as a symbolic link to ``$WORKDIR/cylc-run/$NAME/``.
 
-root-dir{share}=LIST
-  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-  glob-like pattern for matching a host name. The DIR should be the root
-  directory where the suite's share/ directory should be created.
+``root-dir{share}=LIST``
+  A new line delimited list of ``PATTERN=DIR`` pairs. The ``PATTERN`` should
+  be a glob-like pattern for matching a host name. The ``DIR`` should be the
+  root directory where the suite's ``share/`` directory should be created.
 
-root-dir{share/cycle}=LIST
-  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-  glob-like pattern for matching a host name. The DIR should be the root
-  directory where the suite's share/cycle/ directory should be created.
+``root-dir{share/cycle}=LIST``
+  A new line delimited list of ``PATTERN=DIR`` pairs. The ``PATTERN`` should
+  be a glob-like pattern for matching a host name. The ``DIR`` should be the
+  root directory where the suite's ``share/cycle/`` directory should be
+  created.
 
-root-dir{work}=LIST
-  A new line delimited list of PATTERN=DIR pairs. The PATTERN should be a
-  glob-like pattern for matching a host name. The DIR should be the root
-  directory where the suite's work/ directory for tasks should be created.
+``root-dir{work}=LIST``
+  A new line delimited list of ``PATTERN=DIR`` pairs. The ``PATTERN`` should
+  be a glob-like pattern for matching a host name. The ``DIR`` should be the
+  root directory where the suite's ``work/`` directory for tasks should be
+  created.
 
-root-dir-share=LIST
-  Deprecated. Same as root-dir{share}=LIST.
+``root-dir-share=LIST``
+  Deprecated. Same as ``root-dir{share}=LIST``.
 
-root-dir-work=LIST
-  Deprecated. Same as root-dir{work}=LIST.
+``root-dir-work=LIST``
+  Deprecated. Same as ``root-dir{work}=LIST``.
 
 Suite Configuration: Suite Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The suite information file rose-suite.info should contain the information on
-identify and the purpose of the suite. It has no sections, only KEY=VALUE
-pairs. The owner, project and title settings are compulsory. Otherwise,
-any KEY=VALUE pairs can appear in this file. If the name of a KEY ends
-with -list, the value is expected to be a space-delimited list. The
-following keys are known to have special meanings:
+The suite information file ``rose-suite.info`` should contain the information
+on identify and the purpose of the suite. It has no sections, only
+``KEY=VALUE`` pairs. The ``owner``, ``project`` and ``title`` settings are
+compulsory. Otherwise, any ``KEY=VALUE`` pairs can appear in this file. If
+the name of a ``KEY`` ends with ``-list``, the value is expected to be a
+space-delimited list. The following keys are known to have special meanings:
 
-owner
+``owner``
   Specify the user ID of the owner of the suite. The owner has full commit
   access to the suite. Only the owner can delete the suite, pass the suite's
   ownership to someone else or change the access-list.
 
-project
+``project``
   Specify the name of the project associated with the suite.
 
-title
+``title``
   Specify a short title of the suite.
 
-access-list
-  Specify a list of users with commit access to trunk of the suite. A * in
+``access-list``
+  Specify a list of users with commit access to trunk of the suite. A ``*`` in
   the list means that anyone can commit to the trunk of the suite. Setting
   this blank or omitting the setting means that nobody apart from the owner
   can commit to the trunk. Only the suite owner can change the access list.
 
-description
+``description``
   Specify a long description of the suite.
 
-sub-project
-  Specify a sub-division of project, if applicable.
+``sub-project``
+  Specify a sub-division of ``project``, if applicable.
 
 
 Application Configuration
@@ -418,7 +423,7 @@ Application Configuration
 The configuration of an application is represented by a directory. It may
 contain the following:
 
-* rose-app.conf: a compulsory configuration file in the modified INI format.
+* ``rose-app.conf``: a compulsory configuration file in the modified INI format.
   See below for detail. It contains the following information:
 
   * the command(s) to run.
@@ -426,26 +431,28 @@ contain the following:
   * the list of environment variables.
   * other configurations that can be represented in un-ordered key=value
     pairs, e.g. Fortran namelists.
-* file/ directory: other input files, e.g.:
 
-  * FCM configuration files (requires ordering of key=value pairs).
+* ``file/`` directory: other input files, e.g.:
+
+  * FCM configuration files (requires ordering of ``key=value`` pairs).
   * STASH files.
-  * other configuration files that require more than section=key=value.
+  * other configuration files that require more than ``section=key=value``.
 
   Files in this directory are copied to the working directory in run time.
 
-  Note: If there is a clash between a [file:*] section and a file under file/,
-  the setting in the [file:*] section takes precedence. E.g. Suppose we have
-  a file file/hello.txt. In the absence of [file:hello.txt], it will copy
-  file/hello.txt to $PWD/hello.txt in run time. However, if we have a
-  [file:hello.txt] section and a source=SOURCE setting, then it will install
-  the file from SOURCE instead. If we have [!file:hello.txt], then the file
-  will not be installed at all.
-* bin/ directory for e.g. scripts and executables used by the application at
-  run time. If a bin/ exists in the application configuration, it will 
-  prepended to the PATH environment variable at run time.
-* meta/ directory for the metadata of the application.
-* opt/ directory. For detail, see Optional Configuration.
+  Note: If there is a clash between a ``[file:*]`` section and a file under
+  ``file/``, the setting in the ``[file:*]`` section takes precedence. E.g.
+  Suppose we have a file ``file/hello.txt``. In the absence of
+  ``[file:hello.txt]``, it will copy ``file/hello.txt`` to ``$PWD/hello.txt``
+  in run time. However, if we have a ``[file:hello.txt]`` section and a
+  ``source=SOURCE`` setting, then it will install
+  the file from ``SOURCE`` instead. If we have ``[!file:hello.txt]``, then
+  the file will not be installed at all.
+* ``bin/`` directory for e.g. scripts and executables used by the application
+  at run time. If a ``bin/`` exists in the application configuration, it will 
+  prepended to the ``PATH`` environment variable at run time.
+* ``meta/`` directory for the metadata of the application.
+* ``opt/`` directory. For detail, see Optional Configuration.
 
 E.g. The application configuration directory may look like:
 
@@ -463,114 +470,116 @@ E.g. The application configuration directory may look like:
 Application Configuration File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The rose-app.conf contains a serialised data structure that is an unordered
-map (sections=) of unordered maps (keys=values). There can also be
-keys=values without a section, at the top level. The sections and keys can
-be:
+The ``rose-app.conf`` contains a serialised data structure that is an
+unordered map (``sections=``) of unordered maps (``keys=values``). There can
+also be ``keys=values`` without a section, at the top level. The sections and
+keys can be:
 
-file-install-root
+``file-install-root``
   Root level setting. Specify the root directory to install file targets
   that are specified with a relative path.
 
-meta
+``meta``
   Root level setting. Specify the configuration metadata for the application.
   This is ignored by the application runner, but may be used by other
   Rose utilities, such as the config editor GUI. It can be used to specify
   the application type.
 
-mode
+``mode``
   Root level setting. Specify the name of a builtin application, instead of
-  running a command specified in the [command] section. See also Running
+  running a command specified in the ``[command]`` section. See also Running
   Tasks > rose task-run > Built-in Applications Selection
 
-[command]
+``[command]``
   Specify the command(s) to run. The default key can be used to define the
   default command to run. Other keys can be used to define alternate commands,
   which can be selected at run time.
 
-[env]
-  Specify input environment variables to the command, in KEY=VALUE pairs.
-  The usual $NAME or ${NAME} syntax can be used in values to reference
+``[env]``
+  Specify input environment variables to the command, in ``KEY=VALUE`` pairs.
+  The usual ``$NAME`` or ``${NAME}`` syntax can be used in values to reference
   environment variables that are already defined when the application runner
   is invoked. However, it is unsafe to reference other environment variables
-  defined in this section. Note: UNDEF is a special variable that is always
-  undefined at run time. Reference to it will cause a failure at run time. It
-  can be used to indicate that a value must be overridden at run time. If the
-  value of an environment variable setting begins with a tilde ~, all of the
-  characters preceding the 1st slash / are considered a tilde-prefix. Where
-  possible, a tilde-prefix is replaced with the home directory associated with
-  the specified login name at run time.
+  defined in this section. Note: ``UNDEF`` is a special variable that is
+  always undefined at run time. Reference to it will cause a failure at run
+  time. It can be used to indicate that a value must be overridden at run
+  time. If the value of an environment variable setting begins with a tilde
+  ``~``, all of the characters preceding the 1st slash ``/`` are considered a
+  tilde-prefix. Where possible, a tilde-prefix is replaced with the home
+  directory associated with the specified login name at run time.
 
-[etc]
+``[etc]``
   Specify misc. settings. Currently, only UM defs for science sections are
   thought to require this section.
 
-[file:NAME]
+``[file:NAME]``
   Specify a file/directory to be generated by the application runner at
-  run time. NAME should be a path relative to the run time $PWD, or STDIN.
+  run time. ``NAME`` should be a path relative to the run time ``$PWD``, or
+  ``STDIN``.
 
-  * E.g. file:app/APP=source=LOCATION.
+  * E.g. ``file:app/APP=source=LOCATION``.
   * See Appendix: File Creation Mode.
 
-[namelist:NAME]
-  Specify a namelist with the group name called NAME, which can be
-  referred to by a source setting of a file. Each setting in a namelist:NAME
-  section is a KEY=VALUE pair exactly like a normal Fortran namelist, but
-  without the trailing comma.
+``[namelist:NAME]``
+  Specify a namelist with the group name called ``NAME``, which can be
+  referred to by a ``source`` setting of a file. Each setting in a
+  ``namelist:NAME`` section is a ``KEY=VALUE`` pair exactly like a normal
+  Fortran namelist, but without the trailing comma.
 
-[namelist:NAME(SORT-INDEX)]
-  Same as [namelist:NAME] but:
+``[namelist:NAME(SORT-INDEX)]``
+  Same as ``[namelist:NAME]`` but:
 
-  * It allows the source setting of a file to refer to all
-    [namelist:NAME(SORT-INDEX)] as namelist:NAME(:), and the namelist groups
-    will be sorted alphanumerically by the SORT-INDEX.
+  * It allows the ``source`` setting of a file to refer to all
+    ``[namelist:NAME(SORT-INDEX)]`` as ``namelist:NAME(:)``, and the namelist
+    groups will be sorted alphanumerically by the ``SORT-INDEX``.
   * It allows different namelist files to have namelists with the same group
     name. These will all inherit the same group configuration metadata
-    (from [namelist:NAME]).
+    (from ``[namelist:NAME]``).
 
-[namelist:NAME{CATEGORY}] or [namelist:NAME{CATEGORY}(SORT-INDEX)]
-  Same as [namelist:NAME(SORT-INDEX)] but:
+``[namelist:NAME{CATEGORY}]`` or ``[namelist:NAME{CATEGORY}(SORT-INDEX)]``
+  Same as ``[namelist:NAME(SORT-INDEX)]`` but:
 
   * An alternate way for grouping namelists. This allows the same namelist
     to have different usage and configuration metadata according to its
     category. Namelists will inherit configuration metadata from their basic
-    group [namelist:NAME] as well as from their specific category
-    [namelist:NAME{CATEGORY}].
+    group ``[namelist:NAME]`` as well as from their specific category
+    ``[namelist:NAME{CATEGORY}]``.
 
-[poll]
+``[poll]``
   Specify prerequisites to poll for before running the actual application.
   3 types of tests can be performed:
 
-  all-files: A list of space delimited list of file paths. This test passes
-  only if all file paths in the list exist.
+  ``all-files``: A list of space delimited list of file paths. This test
+  passes only if all file paths in the list exist.
 
-  any-files: A list of space delimited list of file paths. This test passes
-  if any file path in the list exists.
+  ``any-files``: A list of space delimited list of file paths. This test
+  passes if any file path in the list exists.
 
-  test: A shell command. This test passes if the command returns a 0 (zero)
-  return code.
+  ``test``: A shell command. This test passes if the command returns a 0
+  (zero) return code.
 
-  Normally, the all-files and any-files tests both test for the existence
-  of file paths. If this is not enough, e.g. you want to test for the existence
-  of a string in each file, you can specify a file-test to do a grep. E.g.:
+  Normally, the ``all-files`` and ``any-files`` tests both test for the
+  existence of file paths. If this is not enough, e.g. you want to test for
+  the existence of a string in each file, you can specify a ``file-test`` to
+  do a ``grep``. E.g.:
 
   .. code-block:: rose
 
      all-files=file1 file2
      file-test=test -e {} && grep -q 'hello' {}
 
-  At runtime, any {} pattern in the above would be replaced with the name
-  of the file. The above make sure that both file1 and file2 exist and that
-  they both contain the string hello.
+  At runtime, any ``{}`` pattern in the above would be replaced with the name
+  of the file. The above make sure that both ``file1`` and ``file2`` exist
+  and that they both contain the string ``hello``.
 
   The above tests will only be performed once when the application runner
-  starts. If a list of delays are added, the tests will be performed a number
-  of times with delays between them. If the prerequisites are still not met
-  after the number of delays, the application runner will fail with a time
-  out. The list is a comma-separated list. The syntax looks like
-  [n*][DURATION], where DURATION is an ISO 8601 duration such as PT5S
-  (5 seconds) or PT10M (10 minutes), and n is an optional number of times
-  to repeat it. E.g.:
+  starts. If a list of ``delays`` are added, the tests will be performed a
+  number of times with delays between them. If the prerequisites are still
+  not met  after the number of delays, the application runner will fail with
+  a time out. The list is a comma-separated list. The syntax looks like
+  ``[n*][DURATION]``, where ``DURATION`` is an ISO 8601 duration such as
+  ``PT5S`` (5 seconds) or ``PT10M`` (10 minutes), and ``n`` is an optional
+  number of times to repeat it. E.g.:
 
   .. code-block:: rose
 
@@ -617,65 +626,64 @@ See Configuration Metadata.
 Appendix: File Creation Mode
 ----------------------------
 
-A [file:TARGET] section may have the following settings:
+A ``[file:TARGET]`` section may have the following settings:
 
-source
+``source``
   A space delimited list of sources for generating this file. A source can
   be the path to a regular file or directory in the file system (globbing is
-  also supported - e.g. using "\*.conf" to mean all .conf files), or it may be
-  a URI to a resource. If a source is a URI, it may point to a section with a
-  supported scheme in the current configuration, e.g. a namelist:NAME section.
-  Otherwise the URI must be in a supported scheme or be given sufficient
-  information for the system to determine its scheme, e.g. via the root level
-  schemes setting described below.
+  also supported - e.g. using ``"\*.conf"`` to mean all ``.conf`` files), or
+  it may be a URI to a resource. If a source is a URI, it may point to a
+  section with a supported scheme in the current configuration, e.g. a
+  ``namelist:NAME section``. Otherwise the URI must be in a supported scheme
+  or be given sufficient information for the system to determine its scheme,
+  e.g. via the root level ``schemes`` setting described below. Normally, a
+  source that does not exist would trigger an error in run time. However, it
+  may be useful to have an optional source for a file sometimes. In which
+  case, the syntax ``source=(SOURCE)`` can be used to specify an optional
+  source. E.g. ``source=namelist:foo`` ``(namelist:bar)`` would allow
+  ``namelist:bar`` to be missing or ignored without an error.
 
-  Normally, a source that does not exist would trigger an error in run
-  time. However, it may be useful to have an optional source for a file
-  sometimes. In which case, the syntax source=(SOURCE) can be used to specify
-  an optional source. E.g. source=namelist:foo (namelist:bar) would allow
-  namelist:bar to be missing or ignored without an error.
-
-checksum
+``checksum``
   The expected MD5 checksum of the target. If specified, the file
   generation will fail if the actual checksum of the target does not match
-  with this setting. This setting is only meaningful if TARGET is a regular
-  file or a symbolic link to a regular file. N.B. An empty value for
+  with this setting. This setting is only meaningful if ``TARGET`` is a
+  regular file or a symbolic link to a regular file. N.B. An empty value for
   checksum tells the system to report the target checksum in verbose mode.
 
-mode
-  auto (default), mkdir, symlink or symlink+. See below.
+``mode``
+  ``auto`` (default), ``mkdir``, ``symlink`` or ``symlink+``. See below.
 
 The following is a list of all the supported usages:
 
-mode=auto,source=
+``mode=auto,source=``
   Target is an empty file.
 
-mode=auto,source=SOURCE
-  Target is a copy of SOURCE.
+``mode=auto,source=SOURCE``
+  Target is a copy of ``SOURCE``.
 
-mode=auto,source=SOURCE-LIST
-  Target is created by concatenating the contents of SOURCE-LIST. The
+``mode=auto,source=SOURCE-LIST``
+  Target is created by concatenating the contents of ``SOURCE-LIST``. The
   sources should either be all files or all directories.
 
-mode=mkdir
+``mode=mkdir``
   Target is a directory.
 
-mode=symlink,source=SOURCE
-  Target is created as a symlink of an FS SOURCE. N.B. In this mode,
-  SOURCE must be a single source. SOURCE does not have to exist when the
-  symbolic link is created.
+``mode=symlink,source=SOURCE``
+  Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
+  ``SOURCE`` must be a single source. ``SOURCE`` does not have to exist when
+  the symbolic link is created.
 
-mode=symlink+,source=SOURCE
-  Target is created as a symlink of an FS SOURCE. N.B. In this mode,
-  SOURCE must be a single source. SOURCE must exist when the symbolic link
-  is created.
+``mode=symlink+,source=SOURCE``
+  Target is created as a symlink of an FS ``SOURCE``. N.B. In this mode,
+  ``SOURCE`` must be a single source. ``SOURCE`` must exist when the symbolic
+  link is created.
 
-The root level schemes setting: While the system would attempt to
+The root level ``schemes`` setting: While the system would attempt to
 automatically detect the scheme of a source, the name of the source can
-sometimes be ambiguous. E.g. A URL with a http scheme can be a path in a
-version control system, or a path to a plain file. The root level schemes
+sometimes be ambiguous. E.g. A URL with a ``http`` scheme can be a path in a
+version control system, or a path to a plain file. The root level ``schemes``
 setting can be used to help the system to do the right thing. The general
-syntax of the value of the root level schemes setting looks like:
+syntax of the value of the root level ``schemes`` setting looks like:
 
    .. code-block:: rose
 
@@ -686,8 +694,8 @@ E.g.:
 
    .. code-block:: rose
 
-      schemes=hpc\*:\*=rsync
-             =http://host/svn-repos/\*=svn
+      schemes=hpc*:*=rsync
+             =http://host/svn-repos/*=svn
 
       [file:foo.txt]
       source=hpc1:/path/to/foo.txt
@@ -695,41 +703,41 @@ E.g.:
       [file:bar.txt]
       source=http://host/svn-repos/path/to/bar.txt
 
-In this example, a URI matching the pattern hpc\*:\* would use the rsync
-scheme to pull the source to the current host, and a URI matching the
-pattern http://host/svn-repos/\* would use the svn scheme. For all other
-URIs, the system will try to make an intelligent guess.
+In this example, a URI matching the pattern ``hpc*:*`` would use the
+``rsync`` scheme to pull the source to the current host, and a URI matching
+the pattern ``http://host/svn-repos/*`` would use the ``svn`` scheme. For all
+other URIs, the system will try to make an intelligent guess.
 
 The system will always match a URI in the order as specified by the setting
 to avoid ambiguity.
 
 The system has built-in support for the following schemes:
 
-fs
+``fs``
   The file system scheme. If a URI looks like an existing path in the
   file system, this scheme will be used.
 
-namelist
-  The namelist scheme. Refer to namelist:NAME sections in the configuration
+``namelist``
+  The namelist scheme. Refer to ``namelist:NAME`` sections in the configuration
   file.
 
-svn
+``svn``
   The Subversion scheme. The location is a Subversion URL or an FCM
-  location keyword. A URI with these schemes svn, svn+ssh and fcm are
-  automatically recognised.
+  location keyword. A URI with these schemes ``svn``, ``svn+ssh`` and ``fcm``
+  are automatically recognised.
 
-rsync
+``rsync``
   This scheme is useful for pulling a file or directory from a remote
-  host using rsync via ssh. A URI should have the form HOST:PATH. (Note: If
-  required, you can use the User setting in ~/.ssh/config to specify the user
-  ID for logging into HOST.)
+  host using ``rsync`` via ``ssh``. A URI should have the form ``HOST:PATH``.
+  (Note: If required, you can use the User setting in ``~/.ssh/config`` to
+  specify the user ID for logging into ``HOST``.)
 
 The application launcher will use the following logic to determine the
 root directory to install file targets with a relative path:
 
-#. If the setting file-install-root=PATH is specified (at the root level)
+#. If the setting ``file-install-root=PATH`` is specified (at the root level)
    in the application configuration file, its value will be used.
-#. If the environment variable ROSE_FILE_INSTALL_ROOT is specified, its
+#. If the environment variable ``ROSE_FILE_INSTALL_ROOT`` is specified, its
    value will be used.
 #. Otherwise, the working directory of the task will be used.
 
@@ -737,17 +745,17 @@ root directory to install file targets with a relative path:
 Appendix: rose-ana configuration format
 ---------------------------------------
 
-The rose-ana builtin application reads information about which analysis
-steps it should perform from the rose-app.conf file for that task. Each of
-the section names (in square brackets) which describe an analysis step must
-follow a particular format:
+The ``rose-ana`` builtin application reads information about which analysis
+steps it should perform from the ``rose-app.conf`` file for that task. Each
+of the section names (in square brackets) which describe an analysis step
+must follow a particular format:
 
-* the name must begin with ana:. This is required for rose-ana to recognise
-  it as a valid section.
+* the name must begin with ``ana``:. This is required for ``rose-ana`` to
+  recognise it as a valid section.
 * the next part gives the name of the class within one of the analysis
   modules, including namespace information; for example to use the built-in
-  FilePattern class from the grepper module you would provide the name
-  grepper.FilePattern.
+  ``FilePattern`` class from the ``grepper`` module you would provide the
+  name ``grepper.FilePattern``.
 * finally an expression within parentheses which may contain any string;
   this should be used to make comparisons using the same class unique, but
   can otherwise simply act as a description or note.
@@ -763,17 +771,19 @@ analysis module you wish to use for details of which options it supports.
 Additionally, some special treatment is applied to all options depending
 on what they contain:
 
-* Environment vars: If the option contains any words prefixed by $ they will
-  be substituted for the equivalent environment variable, if one is available.
-* Lists: If the option contains newlines it will be returned as a list of
+* **Environment vars**: If the option contains any words prefixed by ``$`` they
+  will be substituted for the equivalent environment variable, if one is
+  available.
+* **Lists**: If the option contains newlines it will be returned as a list of
   strings automatically.
-* Argument substitution: If the option contains one or more pairs of empty
-  curved-parentheses {} the option will be returned multiple times with the
-  parentheses substituted once for each argument passed to rose task-run
+* **Argument substitution**: If the option contains one or more pairs of empty
+  curved-parentheses ``{}`` the option will be returned multiple times with
+  the parentheses substituted once for each argument passed to
+  ``rose task-run``
 
-The app may also define a configuration section; [ana:config], whose
+The app may also define a configuration section; ``[ana:config]``, whose
 key-value pairs define app-wide settings that are passed through to the
 analysis classes. In the same way that the task options are dependent on
-the class definition; interpretation of the config options is done by the
-lass(es), so their documentation or source code should be consulted for
+the class definition; interpretation of the ``config`` options is done by the
+class(es), so their documentation or source code should be consulted for
 details.

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -487,7 +487,7 @@ Description
 (Deprecated) Use the ``opt.jobs`` setting in the application configuration
 instead.
 
-The number of jobs to run in parallel in ``fcm make``. (default=4)
+The number of jobs to run in parallel in ``fcm make``. (``default=4``)
 
 Used By
 ^^^^^^^

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -62,7 +62,7 @@ the log prefix that will be used for output e.g. for a bunch instance named
 Provided At Runtime By
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* rose-bunch
+* rose bunch
 
    .. TODO - link 'rose bunch' to relevant built-in app page
 
@@ -143,14 +143,15 @@ the current cycle time. ``????`` is a duration:
 
 * A ``__`` (double underscore) prefix denotes a cycle time in the future.
   Otherwise, it is a cycle time in the past.
-* ``PnM`` denotes n months.
-* ``PnW`` denotes n weeks.
-* ``PnD`` or ``nD`` denotes n days.
-* ``PTnH`` or ``TnH`` denotes n hours.
-* ``PTnM`` denotes n minutes.
+* ``PnM`` denotes *n* months.
+* ``PnW`` denotes *n* weeks.
+* ``PnD`` or ``nD`` denotes *n* days.
+* ``PTnH`` or ``TnH`` denotes *n* hours.
+* ``PTnM`` denotes *n* minutes.
 
 E.g. ``ROSE_DATACPT6H`` is the data directory of 6 hours before the current
 cycle time.
+
 E.g. ``ROSE_DATACP1D`` and ``ROSE_DATACPT24H`` are both the data directory
 of 1 day before the current cycle time.
 
@@ -166,7 +167,7 @@ Provided By
 Description
 ^^^^^^^^^^^
 
-The path to the etc directory of the running suite.
+The path to the ``etc`` directory of the running suite.
 
 Provided By
 ^^^^^^^^^^^
@@ -299,19 +300,22 @@ Description
 
 Tell launcher to run:
 
-.. code-block:: bash
+.. NOTEFORWRITERS - bash syntax highlighting is ugly on below code
+   blocks so instead just use 'none'
+
+.. code-block:: none
 
    rose mpi-launch --inner $@
 
 Specify the arguments to ``ulimit``. E.g. Setting this variable to:
 
-.. code-block:: bash
+.. code-block:: none
 
    -a -s unlimited -d unlimited -a
 
 results in:
 
-.. code-block:: bash
+.. code-block:: none
 
    ulimit -a; ulimit -s unlimited; ulimit -d unlimited; ulimit -a
 
@@ -504,8 +508,8 @@ Used By
 Description
 ^^^^^^^^^^^
 
-(Deprecated) The mirror target for the mirror step in the ``fcm-make.cfg``
-configuration``.
+(Deprecated) The mirror target for the mirror step in the
+``fcm-make.cfg`` configuration.
 
 Provided By
 ^^^^^^^^^^^

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -13,7 +13,7 @@ Specifies the number of processors to run on. Default is 1.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_APP_COMMAND_KEY``
@@ -27,8 +27,8 @@ Can be set to define which command in an app config to use.
 Used By
 ^^^^^^^
 
-* rose app-run
-* rose task-run
+* :ref:`command-rose-app-run`
+* :ref:`command-rose-task-run`
 
 
 ``ROSE_APP_OPT_CONF_KEYS``
@@ -45,8 +45,8 @@ in first-to-last order.
 Used By
 ^^^^^^^
 
-* rose app-run
-* rose task-run
+* :ref:`command-rose-app-run`
+* :ref:`command-rose-task-run`
 
 
 ``ROSE_BUNCH_LOG_PREFIX``
@@ -62,7 +62,9 @@ the log prefix that will be used for output e.g. for a bunch instance named
 Provided At Runtime By
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* rose bunch
+* rose-bunch
+
+   .. TODO - link 'rose bunch' to relevant built-in app page
 
 
 ``ROSE_CONF_PATH``
@@ -79,7 +81,7 @@ normal behaviour is to search for and load ``rose.conf`` from
 Used By
 ^^^^^^^
 
-* rose test-battery
+* :ref:`command-rose-test-battery`
 
 
 ``ROSE_CYCLING_MODE``
@@ -94,12 +96,12 @@ The cycling mode to use when manipulating dates. Can be either ``360day`` or
 Used By
 ^^^^^^^
 
-* rose date
+* :ref:`command-rose-date`
 
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_DATA``
@@ -113,7 +115,7 @@ The path to the data directory of the running suite.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_DATAC``
@@ -127,7 +129,7 @@ The path to the data directory of this cycle time in the running suite.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_DATAC????``
@@ -155,7 +157,7 @@ of 1 day before the current cycle time.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_ETC``
@@ -169,7 +171,7 @@ The path to the etc directory of the running suite.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_FILE_INSTALL_ROOT``
@@ -183,8 +185,8 @@ If specified, change to the specified directory to install files.
 Used By
 ^^^^^^^
 
-* rose app-run
-* rose task-run
+* :ref:`command-rose-app-run`
+* :ref:`command-rose-task-run`
 
 
 ``ROSE_HOME``
@@ -227,7 +229,7 @@ Specifies the launcher program to run the prog.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_LAUNCHER_FILEOPTS``
@@ -242,7 +244,7 @@ selected ``LAUNCHER``.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_LAUNCHER_LIST``
@@ -256,7 +258,7 @@ Specifies an alternative list of launchers.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_LAUNCHER_PREOPTS``
@@ -271,7 +273,7 @@ selected ``LAUNCHER``.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_LAUNCHER_POSTOPTS``
@@ -286,7 +288,7 @@ selected ``LAUNCHER``.
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_LAUNCHER_ULIMIT_OPTS``
@@ -316,7 +318,7 @@ results in:
 Used By
 ^^^^^^^
 
-* rose mpi-launch
+* :ref:`command-rose-mpi-launch`
 
 
 ``ROSE_META_PATH``
@@ -330,8 +332,8 @@ Defines a metadata search path, colon-separated for multiple paths.
 Used by
 ^^^^^^^
 
-* rose config-edit
-* rose macro
+* :ref:`command-rose-config-edit`
+* :ref:`command-rose-macro`
 
 
 ``ROSE_NS``
@@ -360,7 +362,7 @@ The name of the host where the ``rose suite-run`` command was invoked.
 Provided By
 ^^^^^^^^^^^
 
-* rose suite-run
+* :ref:`command-rose-suite-run`
 
 
 ``ROSE_SUITE_DIR``
@@ -374,7 +376,7 @@ The path to the root directory of the running suite.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_SUITE_DIR_REL``
@@ -388,7 +390,7 @@ The path to the root directory of the running suite relative to ``$HOME``.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_SUITE_NAME``
@@ -402,7 +404,7 @@ The name of the running suite.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_SUITE_OPT_CONF_KEYS``
@@ -419,7 +421,7 @@ applied in first-to-last order.
 Used By
 ^^^^^^^
 
-* rose suite-run
+* :ref:`command-rose-suite-run`
 
 
 ``ROSE_TASK_APP``
@@ -433,7 +435,7 @@ Specify a named application configuration.
 Used By
 ^^^^^^^
 
-* rose task-run
+* :ref:`command-rose-task-run`
 
 
 ``ROSE_TASK_CYCLE_TIME``
@@ -447,7 +449,7 @@ The cycle time of the suite task, if there is one.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_TASK_LOG_DIR``
@@ -461,7 +463,7 @@ The directory for log files of the suite task.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_TASK_LOG_ROOT``
@@ -475,7 +477,7 @@ The root path for log files of the suite task.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_TASK_N_JOBS``
@@ -492,8 +494,8 @@ The number of jobs to run in parallel in ``fcm make``. (``default=4``)
 Used By
 ^^^^^^^
 
-* fcm_make built-in application
-* fcm_make2 built-in application
+* ``fcm_make`` built-in application
+* ``fcm_make2`` built-in application
 
 
 ``ROSE_TASK_MIRROR_TARGET``
@@ -508,7 +510,7 @@ configuration``.
 Provided By
 ^^^^^^^^^^^
 
-* fcm_make built-in application
+* ``fcm_make`` built-in application
 
 
 ``ROSE_TASK_NAME``
@@ -522,12 +524,12 @@ The name of the suite task.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 Used By
 ^^^^^^^
 
-* rose app-run
+* :ref:`command-rose-app-run`
 
 
 ``ROSE_TASK_OPTIONS``
@@ -544,8 +546,8 @@ Additional options and arguments for ``fcm make`` or ``rose app-run``.
 Used By
 ^^^^^^^
 
-* fcm_make built-in application
-* fcm_make2 built-in application
+* ``fcm_make`` built-in application
+* ``fcm_make2`` built-in application
 
 
 ``ROSE_TASK_PREFIX``
@@ -559,7 +561,7 @@ The prefix in the task name.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_TASK_SUFFIX``
@@ -573,7 +575,7 @@ The suffix in the task name.
 Provided By
 ^^^^^^^^^^^
 
-* rose task-env
+* :ref:`command-rose-task-env`
 
 
 ``ROSE_UTIL``
@@ -602,4 +604,4 @@ Used and Provided By
 ^^^^^^^^^^^^^^^^^^^^
 
 * rose
-* rose suite-run
+* :ref:`command-rose-suite-run`

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -490,8 +490,9 @@ Provided By
 Description
 ^^^^^^^^^^^
 
-(Deprecated) Use the ``opt.jobs`` setting in the application configuration
-instead.
+.. warning::
+   (Deprecated) Use the ``opt.jobs`` setting in the application configuration
+   instead.
 
 The number of jobs to run in parallel in ``fcm make``. (``default=4``)
 
@@ -508,8 +509,10 @@ Used By
 Description
 ^^^^^^^^^^^
 
-(Deprecated) The mirror target for the mirror step in the
-``fcm-make.cfg`` configuration.
+.. warning::
+   (Deprecated)
+
+The mirror target for the mirror step in the ``fcm-make.cfg`` configuration.
 
 Provided By
 ^^^^^^^^^^^
@@ -542,8 +545,9 @@ Used By
 Description
 ^^^^^^^^^^^
 
-(Deprecated) Use the ``args`` setting in the application configuration
-instead.
+.. warning::
+   (Deprecated) Use the ``args`` setting in the application configuration
+   instead.
 
 Additional options and arguments for ``fcm make`` or ``rose app-run``.
 

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -1,6 +1,7 @@
 Variables
 =========
 
+
 ``NPROC``
 ---------
 
@@ -13,6 +14,7 @@ Used By
 ^^^^^^^
 
 * rose mpi-launch
+
 
 ``ROSE_APP_COMMAND_KEY``
 ------------------------
@@ -28,22 +30,24 @@ Used By
 * rose app-run
 * rose task-run
 
+
 ``ROSE_APP_OPT_CONF_KEYS``
 --------------------------
 
 Description
 ^^^^^^^^^^^
 
-Each ``KEY`` in this space delimited list switches on an optional configuration
-in an application. The ``(KEY)`` syntax can be used to denote an optional
-configuration that can be missing. The configurations are applied in
-first-to-last order.
+Each ``KEY`` in this space delimited list switches on an optional
+configuration in an application. The ``(KEY)`` syntax can be used to denote
+an optional configuration that can be missing. The configurations are applied
+in first-to-last order.
 
 Used By
 ^^^^^^^
 
 * rose app-run
 * rose task-run
+
 
 ``ROSE_BUNCH_LOG_PREFIX``
 -------------------------
@@ -60,6 +64,7 @@ Provided At Runtime By
 
 * rose bunch
 
+
 ``ROSE_CONF_PATH``
 ------------------
 
@@ -75,6 +80,7 @@ Used By
 ^^^^^^^
 
 * rose test-battery
+
 
 ``ROSE_CYCLING_MODE``
 ---------------------
@@ -95,6 +101,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_DATA``
 -------------
 
@@ -108,6 +115,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_DATAC``
 --------------
 
@@ -120,6 +128,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose task-env
+
 
 ``ROSE_DATAC????``
 ------------------
@@ -148,6 +157,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_ETC``
 ------------
 
@@ -160,6 +170,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose task-env
+
 
 ``ROSE_FILE_INSTALL_ROOT``
 --------------------------
@@ -175,6 +186,7 @@ Used By
 * rose app-run
 * rose task-run
 
+
 ``ROSE_HOME``
 -------------
 
@@ -188,18 +200,21 @@ Used and Provided By
 
 * rose
 
+
 ``ROSE_HOME_BIN``
 -----------------
 
 Description
 ^^^^^^^^^^^
 
-Specifies the path to the ``bin/`` or ``sbin/`` directory of the current Rose utility.
+Specifies the path to the ``bin/`` or ``sbin/`` directory of the current
+Rose utility.
 
 Used and Provided By
 ^^^^^^^^^^^^^^^^^^^^
 
 * rose
+
 
 ``ROSE_LAUNCHER``
 -----------------
@@ -213,6 +228,7 @@ Used By
 ^^^^^^^
 
 * rose mpi-launch
+
 
 ``ROSE_LAUNCHER_FILEOPTS``
 --------------------------
@@ -228,6 +244,7 @@ Used By
 
 * rose mpi-launch
 
+
 ``ROSE_LAUNCHER_LIST``
 ----------------------
 
@@ -241,19 +258,21 @@ Used By
 
 * rose mpi-launch
 
+
 ``ROSE_LAUNCHER_PREOPTS``
 -------------------------
 
 Description
 ^^^^^^^^^^^
 
-Override ``[rose-mpi-launch]launcher-preopts.LAUNCHER`` setting for the selected
-``LAUNCHER``.
+Override ``[rose-mpi-launch]launcher-preopts.LAUNCHER`` setting for the
+selected ``LAUNCHER``.
 
 Used By
 ^^^^^^^
 
 * rose mpi-launch
+
 
 ``ROSE_LAUNCHER_POSTOPTS``
 --------------------------
@@ -261,13 +280,14 @@ Used By
 Description
 ^^^^^^^^^^^
 
-Override ``[rose-mpi-launch]launcher-postopts.LAUNCHER`` setting for the selected
-``LAUNCHER``.
+Override ``[rose-mpi-launch]launcher-postopts.LAUNCHER`` setting for the
+selected ``LAUNCHER``.
 
 Used By
 ^^^^^^^
 
 * rose mpi-launch
+
 
 ``ROSE_LAUNCHER_ULIMIT_OPTS``
 -----------------------------
@@ -298,6 +318,7 @@ Used By
 
 * rose mpi-launch
 
+
 ``ROSE_META_PATH``
 ------------------
 
@@ -311,6 +332,7 @@ Used by
 
 * rose config-edit
 * rose macro
+
 
 ``ROSE_NS``
 -----------
@@ -326,6 +348,7 @@ Used and Provided By
 
 * rose
 
+
 ``ROSE_ORIG_HOST``
 ------------------
 
@@ -338,6 +361,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose suite-run
+
 
 ``ROSE_SUITE_DIR``
 ------------------
@@ -352,6 +376,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_SUITE_DIR_REL``
 ----------------------
 
@@ -364,6 +389,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose task-env
+
 
 ``ROSE_SUITE_NAME``
 -------------------
@@ -378,21 +404,23 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_SUITE_OPT_CONF_KEYS``
 ----------------------------
 
 Description
 ^^^^^^^^^^^
 
-Each ``KEY`` in this space delimited list switches on an optional configuration
-when installing a suite. The ``(KEY)`` syntax can be used to denote an optional
-configuration that can be missing. The configurations are applied in
-first-to-last order.
+Each ``KEY`` in this space delimited list switches on an optional
+configuration when installing a suite. The ``(KEY)`` syntax can be used to
+denote an optional configuration that can be missing. The configurations are
+applied in first-to-last order.
 
 Used By
 ^^^^^^^
 
 * rose suite-run
+
 
 ``ROSE_TASK_APP``
 -----------------
@@ -407,6 +435,7 @@ Used By
 
 * rose task-run
 
+
 ``ROSE_TASK_CYCLE_TIME``
 ------------------------
 
@@ -419,6 +448,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose task-env
+
 
 ``ROSE_TASK_LOG_DIR``
 ---------------------
@@ -433,6 +463,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_TASK_LOG_ROOT``
 ----------------------
 
@@ -445,6 +476,7 @@ Provided By
 ^^^^^^^^^^^
 
 * rose task-env
+
 
 ``ROSE_TASK_N_JOBS``
 --------------------
@@ -463,6 +495,7 @@ Used By
 * fcm_make built-in application
 * fcm_make2 built-in application
 
+
 ``ROSE_TASK_MIRROR_TARGET``
 ---------------------------
 
@@ -476,6 +509,7 @@ Provided By
 ^^^^^^^^^^^
 
 * fcm_make built-in application
+
 
 ``ROSE_TASK_NAME``
 ------------------
@@ -495,13 +529,15 @@ Used By
 
 * rose app-run
 
+
 ``ROSE_TASK_OPTIONS``
 ---------------------
 
 Description
 ^^^^^^^^^^^
 
-(Deprecated) Use the ``args`` setting in the application configuration instead.
+(Deprecated) Use the ``args`` setting in the application configuration
+instead.
 
 Additional options and arguments for ``fcm make`` or ``rose app-run``.
 
@@ -510,6 +546,7 @@ Used By
 
 * fcm_make built-in application
 * fcm_make2 built-in application
+
 
 ``ROSE_TASK_PREFIX``
 --------------------
@@ -524,6 +561,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_TASK_SUFFIX``
 --------------------
 
@@ -537,6 +575,7 @@ Provided By
 
 * rose task-env
 
+
 ``ROSE_UTIL``
 -------------
 
@@ -549,6 +588,7 @@ Used and Provided By
 ^^^^^^^^^^^^^^^^^^^^
 
 * rose
+
 
 ``ROSE_VERSION``
 ----------------

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -64,7 +64,7 @@ Provided At Runtime By
 
 * rose bunch
 
-   .. TODO - link 'rose bunch' to relevant built-in app page
+.. TODO - link 'rose bunch' to relevant built-in app page
 
 
 ``ROSE_CONF_PATH``

--- a/sphinx/user-guide/variables.rst
+++ b/sphinx/user-guide/variables.rst
@@ -1,0 +1,565 @@
+Variables
+=========
+
+``NPROC``
+---------
+
+Description
+^^^^^^^^^^^
+
+Specifies the number of processors to run on. Default is 1.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_APP_COMMAND_KEY``
+------------------------
+
+Description
+^^^^^^^^^^^
+
+Can be set to define which command in an app config to use.
+
+Used By
+^^^^^^^
+
+* rose app-run
+* rose task-run
+
+``ROSE_APP_OPT_CONF_KEYS``
+--------------------------
+
+Description
+^^^^^^^^^^^
+
+Each ``KEY`` in this space delimited list switches on an optional configuration
+in an application. The ``(KEY)`` syntax can be used to denote an optional
+configuration that can be missing. The configurations are applied in
+first-to-last order.
+
+Used By
+^^^^^^^
+
+* rose app-run
+* rose task-run
+
+``ROSE_BUNCH_LOG_PREFIX``
+-------------------------
+
+Description
+^^^^^^^^^^^
+
+Environment variable provided to rose bunch instances at runtime to identify
+the log prefix that will be used for output e.g. for a bunch instance named
+``foo`` then ``ROSE_BUNCH_LOG_PREFIX=foo``.
+
+Provided At Runtime By
+^^^^^^^^^^^^^^^^^^^^^^
+
+* rose bunch
+
+``ROSE_CONF_PATH``
+------------------
+
+Description
+^^^^^^^^^^^
+
+Specify a colon (``:``) separated list of paths for searching and loading
+site/user configuration. If this environment variable is not defined, the
+normal behaviour is to search for and load ``rose.conf`` from
+``$ROSE_HOME/etc`` and then ``$HOME/.metomi``.
+
+Used By
+^^^^^^^
+
+* rose test-battery
+
+``ROSE_CYCLING_MODE``
+---------------------
+
+Description
+^^^^^^^^^^^
+
+The cycling mode to use when manipulating dates. Can be either ``360day`` or
+``gregorian``.
+
+Used By
+^^^^^^^
+
+* rose date
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_DATA``
+-------------
+
+Description
+^^^^^^^^^^^
+
+The path to the data directory of the running suite.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_DATAC``
+--------------
+
+Description
+^^^^^^^^^^^
+
+The path to the data directory of this cycle time in the running suite.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_DATAC????``
+------------------
+
+Description
+^^^^^^^^^^^
+
+The path to the data directory of the cycle time with an offset relative to
+the current cycle time. ``????`` is a duration:
+
+* A ``__`` (double underscore) prefix denotes a cycle time in the future.
+  Otherwise, it is a cycle time in the past.
+* ``PnM`` denotes n months.
+* ``PnW`` denotes n weeks.
+* ``PnD`` or ``nD`` denotes n days.
+* ``PTnH`` or ``TnH`` denotes n hours.
+* ``PTnM`` denotes n minutes.
+
+E.g. ``ROSE_DATACPT6H`` is the data directory of 6 hours before the current
+cycle time.
+E.g. ``ROSE_DATACP1D`` and ``ROSE_DATACPT24H`` are both the data directory
+of 1 day before the current cycle time.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_ETC``
+------------
+
+Description
+^^^^^^^^^^^
+
+The path to the etc directory of the running suite.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_FILE_INSTALL_ROOT``
+--------------------------
+
+Description
+^^^^^^^^^^^
+
+If specified, change to the specified directory to install files.
+
+Used By
+^^^^^^^
+
+* rose app-run
+* rose task-run
+
+``ROSE_HOME``
+-------------
+
+Description
+^^^^^^^^^^^
+
+Specifies the path to the rose home directory.
+
+Used and Provided By
+^^^^^^^^^^^^^^^^^^^^
+
+* rose
+
+``ROSE_HOME_BIN``
+-----------------
+
+Description
+^^^^^^^^^^^
+
+Specifies the path to the ``bin/`` or ``sbin/`` directory of the current Rose utility.
+
+Used and Provided By
+^^^^^^^^^^^^^^^^^^^^
+
+* rose
+
+``ROSE_LAUNCHER``
+-----------------
+
+Description
+^^^^^^^^^^^
+
+Specifies the launcher program to run the prog.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_LAUNCHER_FILEOPTS``
+--------------------------
+
+Description
+^^^^^^^^^^^
+
+Override ``[rose-mpi-launch]launcher-fileopts.LAUNCHER`` setting for the
+selected ``LAUNCHER``.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_LAUNCHER_LIST``
+----------------------
+
+Description
+^^^^^^^^^^^
+
+Specifies an alternative list of launchers.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_LAUNCHER_PREOPTS``
+-------------------------
+
+Description
+^^^^^^^^^^^
+
+Override ``[rose-mpi-launch]launcher-preopts.LAUNCHER`` setting for the selected
+``LAUNCHER``.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_LAUNCHER_POSTOPTS``
+--------------------------
+
+Description
+^^^^^^^^^^^
+
+Override ``[rose-mpi-launch]launcher-postopts.LAUNCHER`` setting for the selected
+``LAUNCHER``.
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_LAUNCHER_ULIMIT_OPTS``
+-----------------------------
+
+Description
+^^^^^^^^^^^
+
+Tell launcher to run:
+
+.. code-block:: bash
+
+   rose mpi-launch --inner $@
+
+Specify the arguments to ``ulimit``. E.g. Setting this variable to:
+
+.. code-block:: bash
+
+   -a -s unlimited -d unlimited -a
+
+results in:
+
+.. code-block:: bash
+
+   ulimit -a; ulimit -s unlimited; ulimit -d unlimited; ulimit -a
+
+Used By
+^^^^^^^
+
+* rose mpi-launch
+
+``ROSE_META_PATH``
+------------------
+
+Description
+^^^^^^^^^^^
+
+Defines a metadata search path, colon-separated for multiple paths.
+
+Used by
+^^^^^^^
+
+* rose config-edit
+* rose macro
+
+``ROSE_NS``
+-----------
+
+Description
+^^^^^^^^^^^
+
+Defines the rose namespace. Used to identify if a utility belongs to ``rose``
+or ``rosie``.
+
+Used and Provided By
+^^^^^^^^^^^^^^^^^^^^
+
+* rose
+
+``ROSE_ORIG_HOST``
+------------------
+
+Description
+^^^^^^^^^^^
+
+The name of the host where the ``rose suite-run`` command was invoked.
+
+Provided By
+^^^^^^^^^^^
+
+* rose suite-run
+
+``ROSE_SUITE_DIR``
+------------------
+
+Description
+^^^^^^^^^^^
+
+The path to the root directory of the running suite.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_SUITE_DIR_REL``
+----------------------
+
+Description
+^^^^^^^^^^^
+
+The path to the root directory of the running suite relative to ``$HOME``.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_SUITE_NAME``
+-------------------
+
+Description
+^^^^^^^^^^^
+
+The name of the running suite.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_SUITE_OPT_CONF_KEYS``
+----------------------------
+
+Description
+^^^^^^^^^^^
+
+Each ``KEY`` in this space delimited list switches on an optional configuration
+when installing a suite. The ``(KEY)`` syntax can be used to denote an optional
+configuration that can be missing. The configurations are applied in
+first-to-last order.
+
+Used By
+^^^^^^^
+
+* rose suite-run
+
+``ROSE_TASK_APP``
+-----------------
+
+Description
+^^^^^^^^^^^
+
+Specify a named application configuration.
+
+Used By
+^^^^^^^
+
+* rose task-run
+
+``ROSE_TASK_CYCLE_TIME``
+------------------------
+
+Description
+^^^^^^^^^^^
+
+The cycle time of the suite task, if there is one.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_TASK_LOG_DIR``
+---------------------
+
+Description
+^^^^^^^^^^^
+
+The directory for log files of the suite task.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_TASK_LOG_ROOT``
+----------------------
+
+Description
+^^^^^^^^^^^
+
+The root path for log files of the suite task.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_TASK_N_JOBS``
+--------------------
+
+Description
+^^^^^^^^^^^
+
+(Deprecated) Use the ``opt.jobs`` setting in the application configuration
+instead.
+
+The number of jobs to run in parallel in ``fcm make``. (default=4)
+
+Used By
+^^^^^^^
+
+* fcm_make built-in application
+* fcm_make2 built-in application
+
+``ROSE_TASK_MIRROR_TARGET``
+---------------------------
+
+Description
+^^^^^^^^^^^
+
+(Deprecated) The mirror target for the mirror step in the ``fcm-make.cfg``
+configuration``.
+
+Provided By
+^^^^^^^^^^^
+
+* fcm_make built-in application
+
+``ROSE_TASK_NAME``
+------------------
+
+Description
+^^^^^^^^^^^
+
+The name of the suite task.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+Used By
+^^^^^^^
+
+* rose app-run
+
+``ROSE_TASK_OPTIONS``
+---------------------
+
+Description
+^^^^^^^^^^^
+
+(Deprecated) Use the ``args`` setting in the application configuration instead.
+
+Additional options and arguments for ``fcm make`` or ``rose app-run``.
+
+Used By
+^^^^^^^
+
+* fcm_make built-in application
+* fcm_make2 built-in application
+
+``ROSE_TASK_PREFIX``
+--------------------
+
+Description
+^^^^^^^^^^^
+
+The prefix in the task name.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_TASK_SUFFIX``
+--------------------
+
+Description
+^^^^^^^^^^^
+
+The suffix in the task name.
+
+Provided By
+^^^^^^^^^^^
+
+* rose task-env
+
+``ROSE_UTIL``
+-------------
+
+Description
+^^^^^^^^^^^
+
+Used to identify which ``rose`` or ``rosie`` utility is being run.
+
+Used and Provided By
+^^^^^^^^^^^^^^^^^^^^
+
+* rose
+
+``ROSE_VERSION``
+----------------
+
+Description
+^^^^^^^^^^^
+
+The current version of Rose.
+
+Used and Provided By
+^^^^^^^^^^^^^^^^^^^^
+
+* rose
+* rose suite-run


### PR DESCRIPTION
Pure lifting and pasting of 2012-16 Rose Documentation 'Rose Reference Guide' text into new indexed '.rst' files, with restructuring to abide by reStructuredText markup.